### PR TITLE
Fix negative expires_ms and avoid worker freezing while using cron

### DIFF
--- a/arq/connections.py
+++ b/arq/connections.py
@@ -167,9 +167,7 @@ class ArqRedis(BaseRedis):
             else:
                 score = enqueue_time_ms
 
-            expires_ms = expires_ms or (
-                1 if score - enqueue_time_ms < 1 else score - enqueue_time_ms + self.expires_extra_ms
-            )
+            expires_ms = expires_ms or score - enqueue_time_ms + self.expires_extra_ms
 
             job = serialize_job(function, args, kwargs, _job_try, enqueue_time_ms, serializer=self.job_serializer)
             pipe.multi()

--- a/arq/connections.py
+++ b/arq/connections.py
@@ -167,7 +167,9 @@ class ArqRedis(BaseRedis):
             else:
                 score = enqueue_time_ms
 
-            expires_ms = expires_ms or score - enqueue_time_ms + self.expires_extra_ms
+            expires_ms = expires_ms or (
+                1 if score - enqueue_time_ms < 1 else score - enqueue_time_ms + self.expires_extra_ms
+            )
 
             job = serialize_job(function, args, kwargs, _job_try, enqueue_time_ms, serializer=self.job_serializer)
             pipe.multi()

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -751,7 +751,8 @@ class Worker:
                     job_id = f'{cron_job.name}:{to_unix_ms(cron_job.next_run)}' if cron_job.unique else None
                 job_futures.add(
                     self.pool.enqueue_job(
-                        cron_job.name, _job_id=job_id, _queue_name=self.queue_name, _defer_until=cron_job.next_run
+                        cron_job.name, _job_id=job_id, _queue_name=self.queue_name,
+                        _defer_until=(cron_job.next_run if cron_job.next_run > datetime.now(tz=self.timezone) else None),
                     )
                 )
                 cron_job.calculate_next(cron_job.next_run)

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -751,8 +751,12 @@ class Worker:
                     job_id = f'{cron_job.name}:{to_unix_ms(cron_job.next_run)}' if cron_job.unique else None
                 job_futures.add(
                     self.pool.enqueue_job(
-                        cron_job.name, _job_id=job_id, _queue_name=self.queue_name,
-                        _defer_until=(cron_job.next_run if cron_job.next_run > datetime.now(tz=self.timezone) else None),
+                        cron_job.name,
+                        _job_id=job_id,
+                        _queue_name=self.queue_name,
+                        _defer_until=(
+                            cron_job.next_run if cron_job.next_run > datetime.now(tz=self.timezone) else None
+                        ),
                     )
                 )
                 cron_job.calculate_next(cron_job.next_run)


### PR DESCRIPTION
We're encouraging issue with negative expires_ms while excessively using frequent cron jobs. It's happening rarely, but is causing worker freezes which is pretty annoying in production.

The issue is also mentioned here: https://github.com/python-arq/arq/issues/447

To reproduce:
1. Schedule a cron task.
2. Put a debugger breakpoint to https://github.com/python-arq/arq/blob/main/arq/worker.py#L752 (emulating some delay here: https://github.com/python-arq/arq/blob/main/arq/worker.py#L724)
3. It will cause `_defer_until` to be in the past.
4. It will cause `expires_ms` to be negative here: https://github.com/python-arq/arq/blob/main/arq/connections.py#L170
5. Raises 
```
Task exception was never retrieved
future: <Task finished name='Task-5' coro=<Worker.async_run() done, defined at /Users/matvey/Desktop/keep-oss/.venv/lib/python3.11/site-packages/arq/worker.py:315> exception=ResponseError('Command # 1 (PSETEX arq:job:cron:process_background_ai_task:1726036281123 -319 �\x04�H\x00\x00\x00\x00\x00\x00\x00}�(�\x01t�N�\x01f��\x1fcron:process_background_ai_task��\x01a�)�\x01k�}��\x02et��\x06r��ߑ\x01u.) of pipeline caused error: ("invalid expire time in \'psetex\' command",)')>
Traceback (most recent call last):
  File "/Users/matvey/Desktop/keep-oss/.venv/lib/python3.11/site-packages/arq/worker.py", line 320, in async_run
    await self.main_task
  File "/Users/matvey/Desktop/keep-oss/.venv/lib/python3.11/site-packages/arq/worker.py", line 361, in main
    await self._poll_iteration()
  File "/Users/matvey/Desktop/keep-oss/.venv/lib/python3.11/site-packages/arq/worker.py", line 401, in _poll_iteration
    await self.heart_beat()
  File "/Users/matvey/Desktop/keep-oss/.venv/lib/python3.11/site-packages/arq/worker.py", line 727, in heart_beat
    await self.run_cron(now, cron_window_size)
  File "/Users/matvey/Desktop/keep-oss/.venv/lib/python3.11/site-packages/arq/worker.py", line 759, in run_cron
    job_futures and await asyncio.gather(*job_futures)
  File "/Users/matvey/Desktop/keep-oss/.venv/lib/python3.11/site-packages/arq/connections.py", line 177, in enqueue_job
    await pipe.execute()
  File "/Users/matvey/Desktop/keep-oss/.venv/lib/python3.11/site-packages/redis/asyncio/client.py", line 1399, in execute
    return await conn.retry.call_with_retry(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/matvey/Desktop/keep-oss/.venv/lib/python3.11/site-packages/redis/asyncio/retry.py", line 59, in call_with_retry
    return await do()
           ^^^^^^^^^^
  File "/Users/matvey/Desktop/keep-oss/.venv/lib/python3.11/site-packages/redis/asyncio/client.py", line 1287, in _execute_transaction
    self.raise_first_error(commands, response)
  File "/Users/matvey/Desktop/keep-oss/.venv/lib/python3.11/site-packages/redis/asyncio/client.py", line 1326, in raise_first_error
    raise r
redis.exceptions.ResponseError: Command # 1 (PSETEX arq:job:cron:process_background_ai_task:1726036281123 -319 ��H}�(�t�N�f��cron:process_background_ai_task��a�)�k�}��et��r��ߑu.) of pipeline caused error: ("invalid expire time in 'psetex' command",)
```
6. Worker will stay in the "frozen" state not executing tasks.

Thank you for the library! ❤️