### PR TITLE
PoC: Redis Streams for immediate task delivery 

### DIFF
--- a/arq/connections.py
+++ b/arq/connections.py
@@ -13,8 +13,16 @@ from redis.asyncio.retry import Retry
 from redis.asyncio.sentinel import Sentinel
 from redis.exceptions import RedisError, WatchError
 
-from .constants import default_queue_name, expires_extra_ms, job_key_prefix, result_key_prefix
+from .constants import (
+    default_queue_name,
+    expires_extra_ms,
+    job_key_prefix,
+    job_message_id_prefix,
+    result_key_prefix,
+    stream_key_suffix,
+)
 from .jobs import Deserializer, Job, JobDef, JobResult, Serializer, deserialize_job, serialize_job
+from .lua import publish_job_lua
 from .utils import timestamp_ms, to_ms, to_unix_ms
 
 logger = logging.getLogger('arq.connections')
@@ -115,6 +123,7 @@ class ArqRedis(BaseRedis):
             kwargs['connection_pool'] = pool_or_conn
         self.expires_extra_ms = expires_extra_ms
         super().__init__(**kwargs)
+        self.publish_to_stream_script = self.register_script(publish_job_lua)
 
     async def enqueue_job(
         self,
@@ -165,20 +174,57 @@ class ArqRedis(BaseRedis):
             elif defer_by_ms:
                 score = enqueue_time_ms + defer_by_ms
             else:
-                score = enqueue_time_ms
+                score = None
 
-            expires_ms = expires_ms or score - enqueue_time_ms + self.expires_extra_ms
+            expires_ms = expires_ms or (score or enqueue_time_ms) - enqueue_time_ms + self.expires_extra_ms
 
-            job = serialize_job(function, args, kwargs, _job_try, enqueue_time_ms, serializer=self.job_serializer)
+            job = serialize_job(
+                function,
+                args,
+                kwargs,
+                _job_try,
+                enqueue_time_ms,
+                serializer=self.job_serializer,
+            )
             pipe.multi()
             pipe.psetex(job_key, expires_ms, job)
-            pipe.zadd(_queue_name, {job_id: score})
+
+            if score is not None:
+                pipe.zadd(_queue_name, {job_id: score})
+            else:
+                stream_key = _queue_name + stream_key_suffix
+                job_message_id_key = job_message_id_prefix + job_id
+                await self.publish_to_stream_script(
+                    keys=[stream_key, job_message_id_key],
+                    args=[job_id, str(enqueue_time_ms), str(expires_ms)],
+                    client=pipe,
+                )
+
             try:
                 await pipe.execute()
             except WatchError:
                 # job got enqueued since we checked 'job_exists'
                 return None
-        return Job(job_id, redis=self, _queue_name=_queue_name, _deserializer=self.job_deserializer)
+        return Job(
+            job_id,
+            redis=self,
+            _queue_name=_queue_name,
+            _deserializer=self.job_deserializer,
+        )
+
+    async def get_queue_size(self, queue_name: str | None = None, include_delayed_tasks: bool = True) -> int:
+        if queue_name is None:
+            queue_name = self.default_queue_name
+
+        async with self.pipeline(transaction=True) as pipe:
+            pipe.xlen(queue_name + stream_key_suffix)
+            pipe.zcount(queue_name, '-inf', '+inf')
+            stream_size, delayed_queue_size = await pipe.execute()
+
+        if not include_delayed_tasks:
+            return stream_size
+
+        return stream_size + delayed_queue_size
 
     async def _get_job_result(self, key: bytes) -> JobResult:
         job_id = key[len(result_key_prefix) :].decode()
@@ -213,7 +259,16 @@ class ArqRedis(BaseRedis):
         """
         if queue_name is None:
             queue_name = self.default_queue_name
-        jobs = await self.zrange(queue_name, withscores=True, start=0, end=-1)
+
+        async with self.pipeline(transaction=True) as pipe:
+            pipe.zrange(queue_name, withscores=True, start=0, end=-1)
+            pipe.xrange(queue_name + stream_key_suffix, '-', '+')
+            delayed_jobs, stream_jobs = await pipe.execute()
+
+        jobs = [
+            *delayed_jobs,
+            *[(j[b'job_id'], int(j[b'score'])) for _, j in stream_jobs],
+        ]
         return await asyncio.gather(*[self._get_job_def(job_id, int(score)) for job_id, score in jobs])
 
 

--- a/arq/constants.py
+++ b/arq/constants.py
@@ -1,9 +1,12 @@
 default_queue_name = 'arq:queue'
 job_key_prefix = 'arq:job:'
 in_progress_key_prefix = 'arq:in-progress:'
+job_message_id_prefix = 'arq:message-id:'
 result_key_prefix = 'arq:result:'
 retry_key_prefix = 'arq:retry:'
 abort_jobs_ss = 'arq:abort'
+stream_key_suffix = ':stream'
+default_consumer_group = 'arq:workers'
 # age of items in the abort_key sorted set after which they're deleted
 abort_job_max_age = 60
 health_check_key_suffix = ':health-check'

--- a/arq/jobs.py
+++ b/arq/jobs.py
@@ -5,11 +5,21 @@ import warnings
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
+from itertools import batched
 from typing import Any, Callable, Dict, Optional, Tuple
 
 from redis.asyncio import Redis
 
-from .constants import abort_jobs_ss, default_queue_name, in_progress_key_prefix, job_key_prefix, result_key_prefix
+from .constants import (
+    abort_jobs_ss,
+    default_queue_name,
+    in_progress_key_prefix,
+    job_key_prefix,
+    job_message_id_prefix,
+    result_key_prefix,
+    stream_key_suffix,
+)
+from .lua import get_job_from_stream_lua
 from .utils import ms_to_datetime, poll, timestamp_ms
 
 logger = logging.getLogger('arq.jobs')
@@ -63,12 +73,16 @@ class JobResult(JobDef):
     queue_name: str
 
 
+def _list_to_dict(input_list: list[Any]) -> dict[Any, Any]:
+    return {key: value for key, value in batched(input_list, 2)}
+
+
 class Job:
     """
     Holds data a reference to a job.
     """
 
-    __slots__ = 'job_id', '_redis', '_queue_name', '_deserializer'
+    __slots__ = 'job_id', '_redis', '_queue_name', '_deserializer', '_get_job_from_stream_script'
 
     def __init__(
         self,
@@ -81,6 +95,7 @@ class Job:
         self._redis = redis
         self._queue_name = _queue_name
         self._deserializer = _deserializer
+        self._get_job_from_stream_script = redis.register_script(get_job_from_stream_lua)
 
     async def result(
         self, timeout: Optional[float] = None, *, poll_delay: float = 0.5, pole_delay: Optional[float] = None
@@ -105,7 +120,8 @@ class Job:
             async with self._redis.pipeline(transaction=True) as tr:
                 tr.get(result_key_prefix + self.job_id)
                 tr.zscore(self._queue_name, self.job_id)
-                v, s = await tr.execute()
+                tr.get(job_message_id_prefix + self.job_id)
+                v, s, m = await tr.execute()
 
             if v:
                 info = deserialize_result(v, deserializer=self._deserializer)
@@ -115,7 +131,7 @@ class Job:
                     raise info.result
                 else:
                     raise SerializationError(info.result)
-            elif s is None:
+            elif s is None and m is None:
                 raise ResultNotFound(
                     'Not waiting for job result because the job is not in queue. '
                     'Is the worker function configured to keep result?'
@@ -134,8 +150,22 @@ class Job:
             if v:
                 info = deserialize_job(v, deserializer=self._deserializer)
         if info:
-            s = await self._redis.zscore(self._queue_name, self.job_id)
-            info.score = None if s is None else int(s)
+            async with self._redis.pipeline(transaction=True) as tr:
+                tr.zscore(self._queue_name, self.job_id)
+                await self._get_job_from_stream_script(
+                    keys=[self._queue_name + stream_key_suffix, job_message_id_prefix + self.job_id],
+                    client=tr,
+                )
+                delayed_score, job_info = await tr.execute()
+
+            if delayed_score:
+                info.score = int(delayed_score)
+            elif job_info:
+                _, job_info_payload = job_info
+                info.score = int(_list_to_dict(job_info_payload)[b'score'])
+            else:
+                info.score = None
+
         return info
 
     async def result_info(self) -> Optional[JobResult]:
@@ -157,12 +187,15 @@ class Job:
             tr.exists(result_key_prefix + self.job_id)
             tr.exists(in_progress_key_prefix + self.job_id)
             tr.zscore(self._queue_name, self.job_id)
-            is_complete, is_in_progress, score = await tr.execute()
+            tr.exists(job_message_id_prefix + self.job_id)
+            is_complete, is_in_progress, score, queued = await tr.execute()
 
         if is_complete:
             return JobStatus.complete
         elif is_in_progress:
             return JobStatus.in_progress
+        elif queued:
+            return JobStatus.queued
         elif score:
             return JobStatus.deferred if score > timestamp_ms() else JobStatus.queued
         else:

--- a/arq/jobs.py
+++ b/arq/jobs.py
@@ -5,7 +5,6 @@ import warnings
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from itertools import batched
 from typing import Any, Callable, Dict, Optional, Tuple
 
 from redis.asyncio import Redis
@@ -74,7 +73,7 @@ class JobResult(JobDef):
 
 
 def _list_to_dict(input_list: list[Any]) -> dict[Any, Any]:
-    return {key: value for key, value in batched(input_list, 2)}
+    return dict(zip(input_list[::2], input_list[1::2], strict=True))
 
 
 class Job:

--- a/arq/lua.py
+++ b/arq/lua.py
@@ -1,0 +1,48 @@
+publish_delayed_job_lua = """
+local delayed_queue_key = KEYS[1]
+local stream_key = KEYS[2]
+local job_message_id_key = KEYS[3]
+
+local job_id = ARGV[1]
+local job_message_id_expire_ms = ARGV[2]
+
+local score = redis.call('zscore', delayed_queue_key, job_id)
+if score == nil or score == false then
+    return 0
+end
+
+local message_id = redis.call('xadd', stream_key, '*', 'job_id', job_id, 'score', score)
+redis.call('set', job_message_id_key, message_id, 'px', job_message_id_expire_ms)
+redis.call('zrem', delayed_queue_key, job_id)
+return 1
+"""
+
+publish_job_lua = """
+local stream_key = KEYS[1]
+local job_message_id_key = KEYS[2]
+
+local job_id = ARGV[1]
+local score = ARGV[2]
+local job_message_id_expire_ms = ARGV[3]
+
+local message_id = redis.call('xadd', stream_key, '*', 'job_id', job_id, 'score', score)
+redis.call('set', job_message_id_key, message_id, 'px', job_message_id_expire_ms)
+return message_id
+"""
+
+get_job_from_stream_lua = """
+local stream_key = KEYS[1]
+local job_message_id_key = KEYS[2]
+
+local message_id = redis.call('get', job_message_id_key)
+if message_id == false then
+    return nil
+end
+
+local job = redis.call('xrange', stream_key, message_id, message_id)
+if job == nil then
+    return nil
+end
+
+return job[1]
+"""

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -3,12 +3,14 @@ import contextlib
 import inspect
 import logging
 import signal
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from functools import partial
 from signal import Signals
 from time import time
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, Union, cast
+from uuid import uuid4
 
 from redis.exceptions import ResponseError, WatchError
 
@@ -19,15 +21,19 @@ from .connections import ArqRedis, RedisSettings, create_pool, log_redis_info
 from .constants import (
     abort_job_max_age,
     abort_jobs_ss,
+    default_consumer_group,
     default_queue_name,
     expires_extra_ms,
     health_check_key_suffix,
     in_progress_key_prefix,
     job_key_prefix,
+    job_message_id_prefix,
     keep_cronjob_progress,
     result_key_prefix,
     retry_key_prefix,
+    stream_key_suffix,
 )
+from .lua import publish_delayed_job_lua
 from .utils import (
     args_to_string,
     import_string,
@@ -55,6 +61,13 @@ class Function:
     keep_result_s: Optional[float]
     keep_result_forever: Optional[bool]
     max_tries: Optional[int]
+
+
+@dataclass
+class StreamMessage:
+    message_id: str
+    job_id: str
+    score: int
 
 
 def func(
@@ -188,6 +201,8 @@ class Worker:
         functions: Sequence[Union[Function, 'WorkerCoroutine']] = (),
         *,
         queue_name: Optional[str] = default_queue_name,
+        consumer_group_name: str = default_consumer_group,
+        worker_id: Optional[str] = None,
         cron_jobs: Optional[Sequence[CronJob]] = None,
         redis_settings: Optional[RedisSettings] = None,
         redis_pool: Optional[ArqRedis] = None,
@@ -225,6 +240,8 @@ class Worker:
             else:
                 raise ValueError('If queue_name is absent, redis_pool must be present.')
         self.queue_name = queue_name
+        self.consumer_group_name = consumer_group_name
+        self.worker_id = worker_id or str(uuid4().hex)
         self.cron_jobs: List[CronJob] = []
         if cron_jobs is not None:
             if not all(isinstance(cj, CronJob) for cj in cron_jobs):
@@ -357,17 +374,84 @@ class Worker:
         if self.on_startup:
             await self.on_startup(self.ctx)
 
-        async for _ in poll(self.poll_delay_s):
+        await self.create_consumer_group()
+
+        self.poller_task = asyncio.create_task(self.run_delayed_queue_poller())
+        self.autoclaimer_task = asyncio.create_task(self.run_dead_task_autoclaimer())
+
+        try:
+            await self.run_stream_reader()
+        finally:
+            self.poller_task.cancel()
+            self.autoclaimer_task.cancel()
+            await asyncio.gather(
+                self.poller_task,
+                self.autoclaimer_task,
+                return_exceptions=True,
+            )
+
+    async def run_stream_reader(self) -> None:
+        while True:
             await self._poll_iteration()
 
             if self.burst:
                 if 0 <= self.max_burst_jobs <= self._jobs_started():
                     await asyncio.gather(*self.tasks.values())
                     return None
-                queued_jobs = await self.pool.zcard(self.queue_name)
+                queued_jobs = await self.pool.get_queue_size(self.queue_name)
                 if queued_jobs == 0:
                     await asyncio.gather(*self.tasks.values())
                     return None
+
+    async def run_dead_task_autoclaimer(self) -> None:
+        async for _ in poll(self.poll_delay_s):
+            consumers_info = await self.pool.xinfo_consumers(
+                self.queue_name + stream_key_suffix,
+                groupname=self.consumer_group_name,
+            )
+            for consumer_info in consumers_info:
+                await self.pool.xautoclaim(
+                    self.queue_name + stream_key_suffix,
+                    groupname=self.consumer_group_name,
+                    consumername=consumer_info['name'],
+                    min_idle_time=int(self.in_progress_timeout_s * 1000),
+                )
+
+    async def run_delayed_queue_poller(self) -> None:
+        publish_delayed_job = self.pool.register_script(publish_delayed_job_lua)
+
+        async for _ in poll(self.poll_delay_s):
+            job_ids = await self.pool.zrange(
+                self.queue_name,
+                start=float('-inf'),
+                end=timestamp_ms(),
+                num=self.queue_read_limit,
+                offset=self._queue_read_offset,
+                withscores=True,
+                byscore=True,
+            )
+            for job_id, score in job_ids:
+                expire_ms = int(score - timestamp_ms() + self.expires_extra_ms)
+                if expire_ms <= 0:
+                    expire_ms = self.expires_extra_ms
+
+                await publish_delayed_job(
+                    keys=[
+                        self.queue_name,
+                        self.queue_name + stream_key_suffix,
+                        job_message_id_prefix + job_id.decode(),
+                    ],
+                    args=[job_id.decode(), expire_ms],
+                )
+
+    async def create_consumer_group(self) -> None:
+        with suppress(ResponseError):
+            await self.pool.xgroup_create(
+                name=self.queue_name + stream_key_suffix,
+                groupname=self.consumer_group_name,
+                id='0',
+                mkstream=True,
+            )
 
     async def _poll_iteration(self) -> None:
         """
@@ -382,12 +466,24 @@ class Worker:
             count = min(burst_jobs_remaining, count)
         if self.allow_pick_jobs:
             if self.job_counter < self.max_jobs:
-                now = timestamp_ms()
-                job_ids = await self.pool.zrangebyscore(
-                    self.queue_name, min=float('-inf'), start=self._queue_read_offset, num=count, max=now
+                stream_msgs = await self.pool.xreadgroup(
+                    groupname=self.consumer_group_name,
+                    consumername=self.worker_id,
+                    streams={self.queue_name + stream_key_suffix: '>'},
+                    count=count,
+                    block=int(max(self.poll_delay_s * 1000, 1)),
                 )
+                jobs = []
 
-                await self.start_jobs(job_ids)
+                for _, msgs in stream_msgs:
+                    for msg_id, job in msgs:
+                        jobs.append(
+                            StreamMessage(
+                                message_id=msg_id.decode(), job_id=job[b'job_id'].decode(), score=int(job[b'score'])
+                            )
+                        )
+
+                await self.start_jobs(jobs)
 
         if self.allow_abort_jobs:
             await self._cancel_aborted_jobs()
@@ -428,11 +524,14 @@ class Worker:
         self.job_counter = self.job_counter - 1
         self.sem.release()
 
-    async def start_jobs(self, job_ids: List[bytes]) -> None:
+    async def start_jobs(self, jobs: list[StreamMessage]) -> None:
         """
         For each job id, get the job definition, check it's not running and start it in a task
         """
-        for job_id_b in job_ids:
+        for job in jobs:
+            job_id = job.job_id
+            score = job.score
+
             await self.sem.acquire()
 
             if self.job_counter >= self.max_jobs:
@@ -441,16 +540,13 @@ class Worker:
 
             self.job_counter = self.job_counter + 1
 
-            job_id = job_id_b.decode()
             in_progress_key = in_progress_key_prefix + job_id
             async with self.pool.pipeline(transaction=True) as pipe:
                 await pipe.watch(in_progress_key)
                 ongoing_exists = await pipe.exists(in_progress_key)
-                score = await pipe.zscore(self.queue_name, job_id)
-                if ongoing_exists or not score or score > timestamp_ms():
-                    # job already started elsewhere, or already finished and removed from queue
-                    # if score > ts_now,
-                    # it means probably the job was re-enqueued with a delay in another worker
+
+                if ongoing_exists:
+                    await self._redeliver_job(job)
                     self.job_counter = self.job_counter - 1
                     self.sem.release()
                     logger.debug('job %s already running elsewhere', job_id)
@@ -466,11 +562,30 @@ class Worker:
                     self.sem.release()
                     logger.debug('multi-exec error, job %s already started elsewhere', job_id)
                 else:
-                    t = self.loop.create_task(self.run_job(job_id, int(score)))
+                    t = self.loop.create_task(self.run_job(job_id, job.message_id, score))
                     t.add_done_callback(lambda _: self._release_sem_dec_counter_on_complete())
                     self.tasks[job_id] = t
 
-    async def run_job(self, job_id: str, score: int) -> None:  # noqa: C901
+    async def _redeliver_job(self, job: StreamMessage) -> None:
+        async with self.pool.pipeline(transaction=True) as pipe:
+            stream_key = self.queue_name + stream_key_suffix
+            job_message_id_key = job_message_id_prefix + job.job_id
+
+            pipe.xack(stream_key, self.consumer_group_name, job.message_id)
+            pipe.xdel(stream_key, job.message_id)
+            job_message_id_expire = job.score - timestamp_ms() + self.expires_extra_ms
+            if job_message_id_expire <= 0:
+                job_message_id_expire = self.expires_extra_ms
+
+            await self.pool.publish_to_stream_script(
+                keys=[stream_key, job_message_id_key],
+                args=[job.job_id, str(job.score), str(job_message_id_expire)],
+                client=pipe,
+            )
+
+            await pipe.execute()
+
+    async def run_job(self, job_id: str, message_id: str, score: int) -> None:  # noqa: C901
         start_ms = timestamp_ms()
         async with self.pool.pipeline(transaction=True) as pipe:
             pipe.get(job_key_prefix + job_id)
@@ -504,7 +619,7 @@ class Worker:
                 queue_name=self.queue_name,
                 job_id=job_id,
             )
-            await asyncio.shield(self.finish_failed_job(job_id, result_data_))
+            await asyncio.shield(self.finish_failed_job(job_id, message_id, result_data_))
 
         if not v:
             logger.warning('job %s expired', job_id)
@@ -561,7 +676,7 @@ class Worker:
                 job_id=job_id,
                 serializer=self.job_serializer,
             )
-            return await asyncio.shield(self.finish_failed_job(job_id, result_data))
+            return await asyncio.shield(self.finish_failed_job(job_id, message_id, result_data))
 
         result = no_result
         exc_extra = None
@@ -662,6 +777,8 @@ class Worker:
         await asyncio.shield(
             self.finish_job(
                 job_id,
+                message_id,
+                score,
                 finish,
                 result_data,
                 result_timeout_s,
@@ -677,6 +794,8 @@ class Worker:
     async def finish_job(
         self,
         job_id: str,
+        message_id: str,
+        score: int,
         finish: bool,
         result_data: Optional[bytes],
         result_timeout_s: Optional[float],
@@ -687,33 +806,56 @@ class Worker:
         async with self.pool.pipeline(transaction=True) as tr:
             delete_keys = []
             in_progress_key = in_progress_key_prefix + job_id
+            stream_key = self.queue_name + stream_key_suffix
+            job_message_id_key = job_message_id_prefix + job_id
             if keep_in_progress is None:
                 delete_keys += [in_progress_key]
             else:
                 tr.pexpire(in_progress_key, to_ms(keep_in_progress))
 
+            tr.xack(
+                stream_key,
+                self.consumer_group_name,
+                message_id,
+            )
+            tr.xdel(stream_key, message_id)
+
             if finish:
                 if result_data:
                     expire = None if keep_result_forever else result_timeout_s
                     tr.set(result_key_prefix + job_id, result_data, px=to_ms(expire))
-                delete_keys += [retry_key_prefix + job_id, job_key_prefix + job_id]
+                delete_keys += [retry_key_prefix + job_id, job_key_prefix + job_id, job_message_id_key]
                 tr.zrem(abort_jobs_ss, job_id)
-                tr.zrem(self.queue_name, job_id)
             elif incr_score:
-                tr.zincrby(self.queue_name, incr_score, job_id)
+                delete_keys += [job_message_id_key]
+                tr.zadd(self.queue_name, {job_id: score + incr_score})
+            else:
+                job_message_id_expire = score - timestamp_ms() + self.expires_extra_ms
+                await self.pool.publish_to_stream_script(
+                    keys=[stream_key, job_message_id_key],
+                    args=[job_id, str(score), str(job_message_id_expire)],
+                    client=tr,
+                )
             if delete_keys:
                 tr.delete(*delete_keys)
             await tr.execute()
 
-    async def finish_failed_job(self, job_id: str, result_data: Optional[bytes]) -> None:
+    async def finish_failed_job(self, job_id: str, message_id: str, result_data: Optional[bytes]) -> None:
+        stream_key = self.queue_name + stream_key_suffix
         async with self.pool.pipeline(transaction=True) as tr:
             tr.delete(
                 retry_key_prefix + job_id,
                 in_progress_key_prefix + job_id,
                 job_key_prefix + job_id,
+                job_message_id_prefix + job_id,
             )
             tr.zrem(abort_jobs_ss, job_id)
-            tr.zrem(self.queue_name, job_id)
+            tr.xack(
+                stream_key,
+                self.consumer_group_name,
+                message_id,
+            )
+            tr.xdel(stream_key, message_id)
             # result_data would only be None if serializing the result fails
             keep_result = self.keep_result_forever or self.keep_result_s > 0
             if result_data is not None and keep_result:  # pragma: no branch
@@ -722,6 +864,9 @@ class Worker:
             await tr.execute()
 
     async def heart_beat(self) -> None:
+        if self.poller_task.done():
+            raise self.poller_task.exception()
+
         now = datetime.now(tz=self.timezone)
         await self.record_health()
 

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -490,7 +490,7 @@ class Worker:
             self.queue_name + stream_key_suffix,
             groupname=self.consumer_group_name,
             consumername=self.worker_id,
-            min_idle_time=self.in_progress_timeout_s * 1000,
+            min_idle_time=int(self.in_progress_timeout_s * 1000),
             count=count,
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,10 +94,24 @@ async def arq_redis_retry(test_redis_host: str, test_redis_port: int):
 async def worker(arq_redis):
     worker_: Worker = None
 
-    def create(functions=[], burst=True, poll_delay=0, max_jobs=10, arq_redis=arq_redis, **kwargs):
+    def create(
+        functions=[],
+        burst=True,
+        poll_delay=0,
+        stream_block=0,
+        max_jobs=10,
+        arq_redis=arq_redis,
+        **kwargs,
+    ):
         nonlocal worker_
         worker_ = Worker(
-            functions=functions, redis_pool=arq_redis, burst=burst, poll_delay=poll_delay, max_jobs=max_jobs, **kwargs
+            functions=functions,
+            redis_pool=arq_redis,
+            burst=burst,
+            poll_delay=poll_delay,
+            max_jobs=max_jobs,
+            stream_block=stream_block,
+            **kwargs
         )
         return worker_
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,7 +111,7 @@ async def worker(arq_redis):
             poll_delay=poll_delay,
             max_jobs=max_jobs,
             stream_block=stream_block,
-            **kwargs
+            **kwargs,
         )
         return worker_
 

--- a/tests/test_lua.py
+++ b/tests/test_lua.py
@@ -1,0 +1,122 @@
+import pytest
+from redis.commands.core import AsyncScript
+
+from arq import ArqRedis
+from arq.lua import get_job_from_stream_lua, publish_delayed_job_lua, publish_job_lua
+
+
+@pytest.fixture()
+def publish_delayed_job(arq_redis: ArqRedis) -> AsyncScript:
+    return arq_redis.register_script(publish_delayed_job_lua)
+
+
+@pytest.fixture()
+def publish_job(arq_redis: ArqRedis) -> AsyncScript:
+    return arq_redis.register_script(publish_job_lua)
+
+
+@pytest.fixture()
+def get_job_from_stream(arq_redis: ArqRedis) -> AsyncScript:
+    return arq_redis.register_script(get_job_from_stream_lua)
+
+
+async def test_publish_delayed_job(arq_redis: ArqRedis, publish_delayed_job: AsyncScript) -> None:
+    await arq_redis.zadd('delayed_queue_key', {'job_id': 1000})
+    await publish_delayed_job(
+        keys=[
+            'delayed_queue_key',
+            'stream_key',
+            'job_message_id_key',
+        ],
+        args=[
+            'job_id',
+            '1000',
+        ],
+    )
+
+    stream_msgs = await arq_redis.xrange('stream_key', '-', '+')
+    assert len(stream_msgs) == 1
+
+    saved_msg_id = await arq_redis.get('job_message_id_key')
+
+    msg_id, msg = stream_msgs[0]
+    assert msg == {b'job_id': b'job_id', b'score': b'1000'}
+    assert saved_msg_id == msg_id
+
+    assert await arq_redis.zrange('delayed_queue_key', '-inf', '+inf', byscore=True) == []
+
+    await publish_delayed_job(
+        keys=[
+            'delayed_queue_key',
+            'stream_key',
+            'job_message_id_key',
+        ],
+        args=[
+            'job_id',
+            '1000',
+        ],
+    )
+
+    stream_msgs = await arq_redis.xrange('stream_key', '-', '+')
+    assert len(stream_msgs) == 1
+
+    saved_msg_id = await arq_redis.get('job_message_id_key')
+    assert saved_msg_id == msg_id
+
+
+async def test_publish_job(arq_redis: ArqRedis, publish_job: AsyncScript) -> None:
+    msg_id = await publish_job(
+        keys=[
+            'stream_key',
+            'job_message_id_key',
+        ],
+        args=[
+            'job_id',
+            '1000',
+            '1000',
+        ],
+    )
+
+    stream_msgs = await arq_redis.xrange('stream_key', '-', '+')
+    assert len(stream_msgs) == 1
+
+    saved_msg_id = await arq_redis.get('job_message_id_key')
+    assert saved_msg_id == msg_id
+
+    msg_id, msg = stream_msgs[0]
+    assert msg == {b'job_id': b'job_id', b'score': b'1000'}
+    assert saved_msg_id == msg_id
+
+
+async def test_get_job_from_stream(
+    arq_redis: ArqRedis, publish_job: AsyncScript, get_job_from_stream: AsyncScript
+) -> None:
+    msg_id = await publish_job(
+        keys=[
+            'stream_key',
+            'job_message_id_key',
+        ],
+        args=[
+            'job_id',
+            '1000',
+            '1000',
+        ],
+    )
+
+    job = await get_job_from_stream(
+        keys=[
+            'stream_key',
+            'job_message_id_key',
+        ],
+    )
+
+    assert job == [msg_id, [b'job_id', b'job_id', b'score', b'1000']]
+
+    await arq_redis.delete('job_message_id_key')
+    job = await get_job_from_stream(
+        keys=[
+            'stream_key',
+            'job_message_id_key',
+        ],
+    )
+    assert job is None

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -17,9 +17,9 @@ from arq.jobs import Job, JobStatus
 from arq.worker import (
     FailedJobs,
     JobExecutionFailed,
+    JobMetaInfo,
     Retry,
     RetryJob,
-    StreamMessage,
     Worker,
     async_check_health,
     check_health,
@@ -159,40 +159,6 @@ async def test_job_successful(arq_redis: ArqRedis, worker, caplog):
 
     log = re.sub(r'\d+.\d\ds', 'X.XXs', '\n'.join(r.message for r in caplog.records))
     assert 'X.XXs → testing:foobar()\n  X.XXs ← testing:foobar ● 42' in log
-
-
-async def test_job_retry_race_condition(arq_redis: ArqRedis, worker):
-    async def retry_job(ctx):
-        if ctx['job_try'] == 1:
-            raise Retry(defer=10)
-
-    job_id = 'testing'
-    await arq_redis.enqueue_job('retry_job', _job_id=job_id)
-
-    worker_one: Worker = worker(functions=[func(retry_job, name='retry_job')])
-    worker_two: Worker = worker(functions=[func(retry_job, name='retry_job')])
-
-    assert worker_one.jobs_complete == 0
-    assert worker_one.jobs_failed == 0
-    assert worker_one.jobs_retried == 0
-
-    assert worker_two.jobs_complete == 0
-    assert worker_two.jobs_failed == 0
-    assert worker_two.jobs_retried == 0
-
-    await worker_one.start_jobs([job_id.encode()])
-    await asyncio.gather(*worker_one.tasks.values())
-
-    await worker_two.start_jobs([job_id.encode()])
-    await asyncio.gather(*worker_two.tasks.values())
-
-    assert worker_one.jobs_complete == 0
-    assert worker_one.jobs_failed == 0
-    assert worker_one.jobs_retried == 1
-
-    assert worker_two.jobs_complete == 0
-    assert worker_two.jobs_failed == 0
-    assert worker_two.jobs_retried == 0
 
 
 async def test_job_successful_no_result_logging(arq_redis: ArqRedis, worker, caplog):
@@ -855,7 +821,7 @@ async def test_multi_exec(arq_redis: ArqRedis, worker, caplog):
         *[
             worker.start_jobs(
                 [
-                    StreamMessage(
+                    JobMetaInfo(
                         job_id='testing',
                         message_id='1',
                         score=1,


### PR DESCRIPTION
This pull request introduces a proof of concept for using Redis Streams to improve immediate task delivery in ARQ. The current ARQ implementation faces significant scaling challenges, especially in high-load, distributed environments.

## **Current Problem:**
When handling large volumes of small, quick tasks (e.g., 300 tasks/sec) across multiple workers (10-30+), ARQ’s task distribution model struggles with:
1. Locking Mechanism: On each poll iteration, ARQ attempts to acquire locks for all tasks in the queue, leading to a huge number of Redis calls.
2. High Redis Load: Excessive polling generates unnecessary load on Redis, impacting both performance and scalability.
3. Non-Linear Scaling: Compared to Celery, which can handle similar workloads using only ~10% CPU, ARQ’s CPU usage spikes to ~70% while still hitting scaling limits.

## **Proposed Solution:**
This pull request explores how Redis Streams can be used for immediate task delivery to address these inefficiencies:
* Race Condition Handling: Redis Streams naturally solve race conditions out of the box, eliminating the need for ARQ’s current locking mechanism.
* Reduced Redis Calls: Task acquisition becomes significantly more efficient, reducing the load on Redis and CPU utilization.
* Near-Instant Task Fetching: By avoiding polling, tasks are fetched and delivered almost immediately as they are published.

## **Backwards Compatibility (almost):**
* This implementation only applies to tasks that are ready for immediate execution.
* Delayed tasks will continue to use the existing sorted sets approach.
* The same Redis keys are reused, ensuring smooth upgrades and compatibility with existing ARQ deployments.
* **Warning**: This PR breaks compatibility with Redis v5 since it uses the ﻿XAUTOCLAIM command, which significantly simplifies implementation by avoiding the addition of locks. This command was introduced in Redis 6.2.0. https://redis.io/docs/latest/commands/xautoclaim/ (but potentially it can be replaced with LUA script that does XPENDING + XCLAIM)

## **Key Benefits:**
* Increased Performance and Scalability: Benchmarks demonstrate significant improvements in task delivery performance and overall system scalability.
* Lower CPU Utilization: By minimizing redundant Redis calls, CPU usage is greatly reduced under high-load scenarios on average.
* Immediate Task Delivery: Tasks are fetched in real-time without relying on polling.
* Aligned with ARQ’s Future Vision: This approach integrates seamlessly with ARQ’s roadmap for performance optimization. It implements what was mention in "Future plan for Arq" document https://github.com/python-arq/arq/issues/437 (2. Redis Streams 🚀, 3. Avoid sorted set for immediate jobs, 4. Avoid polling)

This PoC PR that demonstrates that this approach indeed possible and works. After sync with maintainers, this PR can be finished.

## **Benchmark results**
They are not quite reliable as it was tested on a laptop with Redis in a Docker container. But here are some numbers:

### Tasks with no delay

#### Current implementation
```
===============
Published tasks in 2.71 seconds
===============
Starting 1 workers with 25 max jobs
Done 20000 tasks in 80.73 seconds
===============

Published tasks in 2.75 seconds
===============
Starting 10 workers with 25 max jobs
Done 20000 tasks in 80.40 seconds
===============

Published tasks in 2.53 seconds
===============
Starting 20 workers with 25 max jobs
Done 20000 tasks in 91.04 seconds
===============

Published tasks in 3.50 seconds
===============
Starting 40 workers with 25 max jobs
Done 20000 tasks in 133.40 seconds
===============
```

#### Redis streams implementation
```
===============
Published tasks in 3.13 seconds
===============
Starting 1 workers with 25 max jobs
Done 20000 tasks in 31.66 seconds
===============

Published tasks in 2.65 seconds
===============
Starting 10 workers with 25 max jobs
Done 20000 tasks in 7.49 seconds
===============

Published tasks in 2.74 seconds
===============
Starting 20 workers with 25 max jobs
Done 20000 tasks in 6.54 seconds
===============

Published tasks in 2.65 seconds
===============
Starting 40 workers with 25 max jobs
Done 20000 tasks in 6.24 seconds
===============
```

### Tasks with 1 second delay

#### Current implementation
```
===============
Published tasks in 2.51 seconds
===============
Starting 1 workers with 25 max jobs
Done 20000 tasks in 80.25 seconds
===============

Published tasks in 2.64 seconds
===============
Starting 10 workers with 25 max jobs
Done 20000 tasks in 79.59 seconds
===============

Published tasks in 2.56 seconds
===============
Starting 20 workers with 25 max jobs
Done 20000 tasks in 85.00 seconds
===============

Published tasks in 2.48 seconds
===============
Starting 40 workers with 25 max jobs
Done 20000 tasks in 127.51 seconds
===============
```

#### Redis streams implementation

```
===============
Published tasks in 2.50 seconds
===============
Starting 1 workers with 25 max jobs
Done 20000 tasks in 80.49 seconds
===============

Published tasks in 2.75 seconds
===============
Starting 10 workers with 25 max jobs
Done 20000 tasks in 26.39 seconds
===============

Published tasks in 2.52 seconds
===============
Starting 20 workers with 25 max jobs
Done 20000 tasks in 20.30 seconds
===============

Published tasks in 2.71 seconds
===============
Starting 40 workers with 25 max jobs
Done 20000 tasks in 15.98 seconds
===============
```
