### PR TITLE
Fix timeout retries

### DIFF
--- a/arq/worker.py
+++ b/arq/worker.py
@@ -592,7 +592,7 @@ class Worker:
             # run repr(result) and extra inside try/except as they can raise exceptions
             try:
                 result = await asyncio.wait_for(task, timeout_s)
-            except (Exception, asyncio.CancelledError) as e:
+            except (Exception, asyncio.CancelledError, asyncio.TimeoutError) as e:
                 exc_extra = getattr(e, 'extra', None)
                 if callable(exc_extra):
                     exc_extra = exc_extra()
@@ -602,7 +602,7 @@ class Worker:
             finally:
                 del self.job_tasks[job_id]
 
-        except (Exception, asyncio.CancelledError) as e:
+        except (Exception, asyncio.CancelledError, asyncio.TimeoutError) as e:
             finished_ms = timestamp_ms()
             t = (finished_ms - start_ms) / 1000
             if self.retry_jobs and isinstance(e, Retry):
@@ -617,7 +617,7 @@ class Worker:
                 finish = True
                 self.aborting_tasks.remove(job_id)
                 self.jobs_failed += 1
-            elif self.retry_jobs and isinstance(e, (asyncio.CancelledError, RetryJob)):
+            elif self.retry_jobs and isinstance(e, (asyncio.TimeoutError, RetryJob)):
                 logger.info('%6.2fs ↻ %s cancelled, will be run again', t, ref)
                 self.jobs_retried += 1
             else:

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -592,7 +592,7 @@ class Worker:
             # run repr(result) and extra inside try/except as they can raise exceptions
             try:
                 result = await asyncio.wait_for(task, timeout_s)
-            except (Exception, asyncio.CancelledError, asyncio.TimeoutError) as e:
+            except (Exception, asyncio.CancelledError) as e:
                 exc_extra = getattr(e, 'extra', None)
                 if callable(exc_extra):
                     exc_extra = exc_extra()
@@ -602,7 +602,7 @@ class Worker:
             finally:
                 del self.job_tasks[job_id]
 
-        except (Exception, asyncio.CancelledError, asyncio.TimeoutError) as e:
+        except (Exception, asyncio.CancelledError) as e:
             finished_ms = timestamp_ms()
             t = (finished_ms - start_ms) / 1000
             if self.retry_jobs and isinstance(e, Retry):
@@ -617,7 +617,7 @@ class Worker:
                 finish = True
                 self.aborting_tasks.remove(job_id)
                 self.jobs_failed += 1
-            elif self.retry_jobs and isinstance(e, (asyncio.TimeoutError, RetryJob)):
+            elif self.retry_jobs and isinstance(e, (asyncio.CancelledError, asyncio.TimeoutError, RetryJob)):
                 logger.info('%6.2fs ↻ %s cancelled, will be run again', t, ref)
                 self.jobs_retried += 1
             else:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -974,7 +974,7 @@ async def test_job_timeout(arq_redis: ArqRedis, worker, caplog):
     async def longfunc(ctx):
         await asyncio.sleep(0.3)
 
-    caplog.set_level(logging.ERROR)
+    caplog.set_level(logging.INFO)
     await arq_redis.enqueue_job('longfunc', _job_id='testing')
     worker: Worker = worker(functions=[func(longfunc, name='longfunc')], job_timeout=0.2, poll_delay=0.1)
     assert worker.jobs_complete == 0
@@ -986,7 +986,7 @@ async def test_job_timeout(arq_redis: ArqRedis, worker, caplog):
     assert worker.jobs_failed == 1
     assert worker.jobs_retried == worker.max_tries
     log = re.sub(r'\d+.\d\ds', 'X.XXs', '\n'.join(r.message for r in caplog.records))
-    assert 'X.XXs ! testing:longfunc failed, TimeoutError:' in log
+    assert f'X.XXs ! testing:longfunc max retries {worker.max_tries} exceeded' in log
 
 
 async def test_on_job(arq_redis: ArqRedis, worker):

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -980,10 +980,11 @@ async def test_job_timeout(arq_redis: ArqRedis, worker, caplog):
     assert worker.jobs_complete == 0
     assert worker.jobs_failed == 0
     assert worker.jobs_retried == 0
+    assert worker.retry_jobs
     await worker.main()
     assert worker.jobs_complete == 0
     assert worker.jobs_failed == 1
-    assert worker.jobs_retried == 0
+    assert worker.jobs_retried == worker.max_tries
     log = re.sub(r'\d+.\d\ds', 'X.XXs', '\n'.join(r.message for r in caplog.records))
     assert 'X.XXs ! testing:longfunc failed, TimeoutError:' in log
 


### PR DESCRIPTION
I noticed that with retries enabled, there are no timeout retries.
I read the [documentation](https://docs.python.org/3/library/asyncio-task.html#timeouts), and it says that `wait_for` throws a `TimeoutError`, not a `CancelledError`.