### PR TITLE
[feat] priority-based scheduling

### DIFF
--- a/arq/connections.py
+++ b/arq/connections.py
@@ -13,7 +13,18 @@ from redis.asyncio.retry import Retry
 from redis.asyncio.sentinel import Sentinel
 from redis.exceptions import RedisError, WatchError
 
-from .constants import default_queue_name, expires_extra_ms, job_key_prefix, result_key_prefix
+from .constants import (
+    DEFAULT_PRIORITY,
+    MAX_PRIORITY,
+    MIN_PRIORITY,
+    compute_ready_score,
+    default_queue_name,
+    deferred_queue_key,
+    expires_extra_ms,
+    job_key_prefix,
+    ready_queue_key,
+    result_key_prefix,
+)
 from .jobs import Deserializer, Job, JobDef, JobResult, Serializer, deserialize_job, serialize_job
 from .utils import timestamp_ms, to_ms, to_unix_ms
 
@@ -126,6 +137,7 @@ class ArqRedis(BaseRedis):
         _defer_by: Union[None, int, float, timedelta] = None,
         _expires: Union[None, int, float, timedelta] = None,
         _job_try: Optional[int] = None,
+        _priority: int = DEFAULT_PRIORITY,
         **kwargs: Any,
     ) -> Optional[Job]:
         """
@@ -140,9 +152,13 @@ class ArqRedis(BaseRedis):
         :param _expires: do not start or retry a job after this duration;
             defaults to 24 hours plus deferring time, if any
         :param _job_try: useful when re-enqueueing jobs within a job
+        :param _priority: integer priority in the range 1..10 (1 = highest, 10 = lowest);
+            defaults to 5. Within the same priority, jobs run FIFO by enqueue time.
         :param kwargs: any keyword arguments to pass to the function
         :return: :class:`arq.jobs.Job` instance or ``None`` if a job with this ID already exists
         """
+        if not (MIN_PRIORITY <= _priority <= MAX_PRIORITY):
+            raise ValueError(f'_priority must be between {MIN_PRIORITY} and {MAX_PRIORITY}, got {_priority}')
         if _queue_name is None:
             _queue_name = self.default_queue_name
         job_id = _job_id or uuid4().hex
@@ -161,24 +177,79 @@ class ArqRedis(BaseRedis):
 
             enqueue_time_ms = timestamp_ms()
             if _defer_until is not None:
-                score = to_unix_ms(_defer_until)
+                run_at_ms = to_unix_ms(_defer_until)
+                deferred = True
             elif defer_by_ms:
-                score = enqueue_time_ms + defer_by_ms
+                run_at_ms = enqueue_time_ms + defer_by_ms
+                deferred = True
             else:
-                score = enqueue_time_ms
+                run_at_ms = enqueue_time_ms
+                deferred = False
 
-            expires_ms = expires_ms or score - enqueue_time_ms + self.expires_extra_ms
+            expires_ms = expires_ms or run_at_ms - enqueue_time_ms + self.expires_extra_ms
 
-            job = serialize_job(function, args, kwargs, _job_try, enqueue_time_ms, serializer=self.job_serializer)
+            job = serialize_job(
+                function,
+                args,
+                kwargs,
+                _job_try,
+                enqueue_time_ms,
+                priority=_priority,
+                serializer=self.job_serializer,
+            )
             pipe.multi()
             pipe.psetex(job_key, expires_ms, job)
-            pipe.zadd(_queue_name, {job_id: score})
+            if deferred:
+                pipe.zadd(deferred_queue_key(_queue_name), {job_id: run_at_ms})
+            else:
+                pipe.zadd(
+                    ready_queue_key(_queue_name),
+                    {job_id: compute_ready_score(_priority, enqueue_time_ms)},
+                )
             try:
                 await pipe.execute()
             except WatchError:
                 # job got enqueued since we checked 'job_exists'
                 return None
         return Job(job_id, redis=self, _queue_name=_queue_name, _deserializer=self.job_deserializer)
+
+    async def queue_size(self, queue_name: Optional[str] = None) -> int:
+        """
+        Total number of jobs in this queue across both the ready and deferred sub-zsets.
+        """
+        if queue_name is None:
+            queue_name = self.default_queue_name
+        async with self.pipeline(transaction=False) as pipe:
+            pipe.zcard(ready_queue_key(queue_name))
+            pipe.zcard(deferred_queue_key(queue_name))
+            ready, deferred = await pipe.execute()
+        return int(ready) + int(deferred)
+
+    async def job_queue_score(
+        self, queue_name: str, job_id: str
+    ) -> tuple[Optional[int], bool]:
+        """
+        Look up a job's score in the queue. Returns ``(score, is_deferred)``;
+        ``score`` is ``None`` when the job is in neither sub-zset.
+        """
+        async with self.pipeline(transaction=False) as pipe:
+            pipe.zscore(ready_queue_key(queue_name), job_id)
+            pipe.zscore(deferred_queue_key(queue_name), job_id)
+            ready_score, deferred_score = await pipe.execute()
+        if ready_score is not None:
+            return int(ready_score), False
+        if deferred_score is not None:
+            return int(deferred_score), True
+        return None, False
+
+    @staticmethod
+    def zrem_from_queue(pipe: Any, queue_name: str, job_id: str) -> None:
+        """
+        Stage ``ZREM`` against both sub-zsets on an existing pipeline.
+        Idempotent — safe even if the job only lives in one of them.
+        """
+        pipe.zrem(ready_queue_key(queue_name), job_id)
+        pipe.zrem(deferred_queue_key(queue_name), job_id)
 
     async def _get_job_result(self, key: bytes) -> JobResult:
         job_id = key[len(result_key_prefix) :].decode()
@@ -209,11 +280,16 @@ class ArqRedis(BaseRedis):
 
     async def queued_jobs(self, *, queue_name: Optional[str] = None) -> list[JobDef]:
         """
-        Get information about queued, mostly useful when testing.
+        Get information about queued jobs across both the ready and deferred sub-zsets.
+        Mostly useful when testing.
         """
         if queue_name is None:
             queue_name = self.default_queue_name
-        jobs = await self.zrange(queue_name, withscores=True, start=0, end=-1)
+        async with self.pipeline(transaction=False) as pipe:
+            pipe.zrange(ready_queue_key(queue_name), withscores=True, start=0, end=-1)
+            pipe.zrange(deferred_queue_key(queue_name), withscores=True, start=0, end=-1)
+            ready, deferred = await pipe.execute()
+        jobs = list(ready) + list(deferred)
         return await asyncio.gather(*[self._get_job_def(job_id, int(score)) for job_id, score in jobs])
 
 

--- a/arq/connections.py
+++ b/arq/connections.py
@@ -225,9 +225,7 @@ class ArqRedis(BaseRedis):
             ready, deferred = await pipe.execute()
         return int(ready) + int(deferred)
 
-    async def job_queue_score(
-        self, queue_name: str, job_id: str
-    ) -> tuple[Optional[int], bool]:
+    async def job_queue_score(self, queue_name: str, job_id: str) -> tuple[Optional[int], bool]:
         """
         Look up a job's score in the queue. Returns ``(score, is_deferred)``;
         ``score`` is ``None`` when the job is in neither sub-zset.

--- a/arq/constants.py
+++ b/arq/constants.py
@@ -16,3 +16,24 @@ timezone_env_vars = 'ARQ_TIMEZONE', 'arq_timezone', 'TIMEZONE', 'timezone'
 
 # extra time after the job is expected to start when the job key should expire, 1 day in ms
 expires_extra_ms = 86_400_000
+
+# priority constants. ready-zset score = PRIORITY_FACTOR * priority + timestamp_ms,
+# so lower priority value runs first; FIFO is preserved within a tie via the timestamp.
+# 1e15 keeps the priority bucket strictly above any realistic timestamp_ms; doubles still
+# resolve ms-level differences at this magnitude (gap ~2.0 at ~1e16).
+PRIORITY_FACTOR = 10**15
+DEFAULT_PRIORITY = 5
+MIN_PRIORITY = 1
+MAX_PRIORITY = 10
+
+
+def ready_queue_key(queue_name: str) -> str:
+    return f'{queue_name}:ready'
+
+
+def deferred_queue_key(queue_name: str) -> str:
+    return f'{queue_name}:deferred'
+
+
+def compute_ready_score(priority: int, timestamp_ms: int) -> int:
+    return PRIORITY_FACTOR * priority + timestamp_ms

--- a/arq/jobs.py
+++ b/arq/jobs.py
@@ -2,14 +2,25 @@ import asyncio
 import logging
 import pickle
 import warnings
-from dataclasses import dataclass
-from datetime import datetime
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Callable, Optional
 
 from redis.asyncio import Redis
 
-from .constants import abort_jobs_ss, default_queue_name, in_progress_key_prefix, job_key_prefix, result_key_prefix
+from .constants import (
+    DEFAULT_PRIORITY,
+    MIN_PRIORITY,
+    abort_jobs_ss,
+    compute_ready_score,
+    default_queue_name,
+    deferred_queue_key,
+    in_progress_key_prefix,
+    job_key_prefix,
+    ready_queue_key,
+    result_key_prefix,
+)
 from .utils import ms_to_datetime, poll, timestamp_ms
 
 logger = logging.getLogger('arq.jobs')
@@ -39,6 +50,9 @@ class JobStatus(str, Enum):
     not_found = 'not_found'
 
 
+_EPOCH = datetime.fromtimestamp(0, tz=timezone.utc)
+
+
 @dataclass
 class JobDef:
     function: str
@@ -48,6 +62,9 @@ class JobDef:
     enqueue_time: datetime
     score: Optional[int]
     job_id: Optional[str]
+    # priority defaults so existing constructor sites that predate the priority feature keep working;
+    # dataclass inheritance forces every JobResult-only field below to also carry a default.
+    priority: int = DEFAULT_PRIORITY
 
     def __post_init__(self) -> None:
         if isinstance(self.score, float):
@@ -56,11 +73,11 @@ class JobDef:
 
 @dataclass
 class JobResult(JobDef):
-    success: bool
-    result: Any
-    start_time: datetime
-    finish_time: datetime
-    queue_name: str
+    success: bool = False
+    result: Any = None
+    start_time: datetime = field(default_factory=lambda: _EPOCH)
+    finish_time: datetime = field(default_factory=lambda: _EPOCH)
+    queue_name: str = ''
 
 
 class Job:
@@ -104,8 +121,9 @@ class Job:
         async for delay in poll(poll_delay):
             async with self._redis.pipeline(transaction=True) as tr:
                 tr.get(result_key_prefix + self.job_id)
-                tr.zscore(self._queue_name, self.job_id)
-                v, s = await tr.execute()
+                tr.zscore(ready_queue_key(self._queue_name), self.job_id)
+                tr.zscore(deferred_queue_key(self._queue_name), self.job_id)
+                v, ready_score, deferred_score = await tr.execute()
 
             if v:
                 info = deserialize_result(v, deserializer=self._deserializer)
@@ -115,7 +133,7 @@ class Job:
                     raise info.result
                 else:
                     raise SerializationError(info.result)
-            elif s is None:
+            elif ready_score is None and deferred_score is None:
                 raise ResultNotFound(
                     'Not waiting for job result because the job is not in queue. '
                     'Is the worker function configured to keep result?'
@@ -134,9 +152,24 @@ class Job:
             if v:
                 info = deserialize_job(v, deserializer=self._deserializer)
         if info:
-            s = await self._redis.zscore(self._queue_name, self.job_id)
-            info.score = None if s is None else int(s)
+            score, _ = await self._lookup_queue_score()
+            info.score = score
         return info
+
+    async def _lookup_queue_score(self) -> tuple[Optional[int], bool]:
+        """
+        Return ``(score, is_deferred)`` for this job. ``score`` is ``None`` when the job
+        isn't in either sub-zset.
+        """
+        async with self._redis.pipeline(transaction=False) as pipe:
+            pipe.zscore(ready_queue_key(self._queue_name), self.job_id)
+            pipe.zscore(deferred_queue_key(self._queue_name), self.job_id)
+            ready_score, deferred_score = await pipe.execute()
+        if ready_score is not None:
+            return int(ready_score), False
+        if deferred_score is not None:
+            return int(deferred_score), True
+        return None, False
 
     async def result_info(self) -> Optional[JobResult]:
         """
@@ -156,15 +189,18 @@ class Job:
         async with self._redis.pipeline(transaction=True) as tr:
             tr.exists(result_key_prefix + self.job_id)
             tr.exists(in_progress_key_prefix + self.job_id)
-            tr.zscore(self._queue_name, self.job_id)
-            is_complete, is_in_progress, score = await tr.execute()
+            tr.zscore(ready_queue_key(self._queue_name), self.job_id)
+            tr.zscore(deferred_queue_key(self._queue_name), self.job_id)
+            is_complete, is_in_progress, ready_score, deferred_score = await tr.execute()
 
         if is_complete:
             return JobStatus.complete
         elif is_in_progress:
             return JobStatus.in_progress
-        elif score:
-            return JobStatus.deferred if score > timestamp_ms() else JobStatus.queued
+        elif ready_score is not None:
+            return JobStatus.queued
+        elif deferred_score is not None:
+            return JobStatus.deferred
         else:
             return JobStatus.not_found
 
@@ -177,11 +213,16 @@ class Job:
         :param poll_delay: how often to poll redis for the job result
         :return: True if the job aborted properly, False otherwise
         """
-        job_info = await self.info()
-        if job_info and job_info.score and job_info.score > timestamp_ms():
+        # if the job is currently sitting in the deferred sub-zset, hoist it into ready at
+        # top priority so the worker picks it up on the next poll and observes the abort flag.
+        _, is_deferred = await self._lookup_queue_score()
+        if is_deferred:
             async with self._redis.pipeline(transaction=True) as tr:
-                tr.zrem(self._queue_name, self.job_id)
-                tr.zadd(self._queue_name, {self.job_id: 1})
+                tr.zrem(deferred_queue_key(self._queue_name), self.job_id)
+                tr.zadd(
+                    ready_queue_key(self._queue_name),
+                    {self.job_id: compute_ready_score(MIN_PRIORITY, timestamp_ms())},
+                )
                 await tr.execute()
 
         await self._redis.zadd(abort_jobs_ss, {self.job_id: timestamp_ms()})
@@ -215,9 +256,17 @@ def serialize_job(
     job_try: Optional[int],
     enqueue_time_ms: int,
     *,
+    priority: int = DEFAULT_PRIORITY,
     serializer: Optional[Serializer] = None,
 ) -> bytes:
-    data = {'t': job_try, 'f': function_name, 'a': args, 'k': kwargs, 'et': enqueue_time_ms}
+    data = {
+        't': job_try,
+        'f': function_name,
+        'a': args,
+        'k': kwargs,
+        'et': enqueue_time_ms,
+        'priority': priority,
+    }
     if serializer is None:
         serializer = pickle.dumps
     try:
@@ -240,6 +289,7 @@ def serialize_result(
     queue_name: str,
     job_id: str,
     *,
+    priority: int = DEFAULT_PRIORITY,
     serializer: Optional[Serializer] = None,
 ) -> Optional[bytes]:
     data = {
@@ -254,6 +304,7 @@ def serialize_result(
         'ft': finished_ms,
         'q': queue_name,
         'id': job_id,
+        'priority': priority,
     }
     if serializer is None:
         serializer = pickle.dumps
@@ -284,6 +335,7 @@ def deserialize_job(r: bytes, *, deserializer: Optional[Deserializer] = None) ->
             enqueue_time=ms_to_datetime(d['et']),
             score=None,
             job_id=None,
+            priority=d.get('priority', DEFAULT_PRIORITY),
         )
     except Exception as e:
         raise DeserializationError('unable to deserialize job') from e
@@ -291,12 +343,12 @@ def deserialize_job(r: bytes, *, deserializer: Optional[Deserializer] = None) ->
 
 def deserialize_job_raw(
     r: bytes, *, deserializer: Optional[Deserializer] = None
-) -> tuple[str, tuple[Any, ...], dict[str, Any], int, int]:
+) -> tuple[str, tuple[Any, ...], dict[str, Any], int, int, int]:
     if deserializer is None:
         deserializer = pickle.loads
     try:
         d = deserializer(r)
-        return d['f'], d['a'], d['k'], d['t'], d['et']
+        return d['f'], d['a'], d['k'], d['t'], d['et'], d.get('priority', DEFAULT_PRIORITY)
     except Exception as e:
         raise DeserializationError('unable to deserialize job') from e
 
@@ -319,6 +371,7 @@ def deserialize_result(r: bytes, *, deserializer: Optional[Deserializer] = None)
             finish_time=ms_to_datetime(d['ft']),
             queue_name=d.get('q', '<unknown>'),
             job_id=d.get('id', '<unknown>'),
+            priority=d.get('priority', DEFAULT_PRIORITY),
         )
     except Exception as e:
         raise DeserializationError('unable to deserialize job result') from e

--- a/arq/worker.py
+++ b/arq/worker.py
@@ -14,18 +14,32 @@ from typing import TYPE_CHECKING, Any, Callable, Optional, Union, cast
 from redis.exceptions import ResponseError, WatchError
 
 from arq.cron import CronJob
-from arq.jobs import Deserializer, JobResult, SerializationError, Serializer, deserialize_job_raw, serialize_result
+from arq.jobs import (
+    DeserializationError,
+    Deserializer,
+    JobResult,
+    SerializationError,
+    Serializer,
+    deserialize_job,
+    deserialize_job_raw,
+    serialize_result,
+)
 
 from .connections import ArqRedis, RedisSettings, create_pool, log_redis_info
 from .constants import (
+    DEFAULT_PRIORITY,
+    PRIORITY_FACTOR,
     abort_job_max_age,
     abort_jobs_ss,
+    compute_ready_score,
     default_queue_name,
+    deferred_queue_key,
     expires_extra_ms,
     health_check_key_suffix,
     in_progress_key_prefix,
     job_key_prefix,
     keep_cronjob_progress,
+    ready_queue_key,
     result_key_prefix,
     retry_key_prefix,
 )
@@ -369,15 +383,16 @@ class Worker:
                 if 0 <= self.max_burst_jobs <= self._jobs_started():
                     await asyncio.gather(*self.tasks.values())
                     return None
-                queued_jobs = await self.pool.zcard(self.queue_name)
+                queued_jobs = await self.pool.queue_size(self.queue_name)
                 if queued_jobs == 0:
                     await asyncio.gather(*self.tasks.values())
                     return None
 
     async def _poll_iteration(self) -> None:
         """
-        Get ids of pending jobs from the main queue sorted-set data structure and start those jobs, remove
-        any finished tasks from self.tasks.
+        Promote any due-deferred jobs into the ready zset, then get ids of pending jobs from the
+        ready sorted-set (sorted by priority then enqueue time) and start them. Also remove any
+        finished tasks from self.tasks.
         """
         count = self.queue_read_limit
         if self.burst and self.max_burst_jobs >= 0:
@@ -387,9 +402,15 @@ class Worker:
             count = min(burst_jobs_remaining, count)
         if self.allow_pick_jobs:
             if self.job_counter < self.max_jobs:
-                now = timestamp_ms()
+                await self._promote_deferred_jobs()
+                # ready zset is already time-filtered (deferred jobs live in a separate zset),
+                # so we read the lowest-score head with no upper bound on score.
                 job_ids = await self.pool.zrangebyscore(
-                    self.queue_name, min=float('-inf'), start=self._queue_read_offset, num=count, max=now
+                    ready_queue_key(self.queue_name),
+                    min=float('-inf'),
+                    max=float('+inf'),
+                    start=self._queue_read_offset,
+                    num=count,
                 )
 
                 await self.start_jobs(job_ids)
@@ -404,6 +425,37 @@ class Worker:
                 t.result()
 
         await self.heart_beat()
+
+    async def _promote_deferred_jobs(self) -> None:
+        """
+        Move every deferred job whose run-at time has passed into the ready zset, scored by
+        priority (read from the job blob) with the original run-at time as the FIFO tiebreak.
+        Idempotent across competing workers thanks to ZADD/ZREM semantics.
+        """
+        deferred_key = deferred_queue_key(self.queue_name)
+        ready_key = ready_queue_key(self.queue_name)
+        now = timestamp_ms()
+
+        due = await self.pool.zrangebyscore(deferred_key, min=float('-inf'), max=now, withscores=True)
+        if not due:
+            return
+
+        async with self.pool.pipeline(transaction=False) as pipe:
+            for job_id_b, _ in due:
+                pipe.get(job_key_prefix + job_id_b.decode())
+            blobs = await pipe.execute()
+
+        async with self.pool.pipeline(transaction=True) as pipe:
+            for (job_id_b, defer_ms), blob in zip(due, blobs):
+                if blob:
+                    try:
+                        priority = deserialize_job(blob, deserializer=self.job_deserializer).priority
+                    except DeserializationError:
+                        priority = DEFAULT_PRIORITY
+                    pipe.zadd(ready_key, {job_id_b: compute_ready_score(priority, int(defer_ms))})
+                # if the job blob expired we still want to drop the dangling deferred entry
+                pipe.zrem(deferred_key, job_id_b)
+            await pipe.execute()
 
     async def _cancel_aborted_jobs(self) -> None:
         """
@@ -451,11 +503,10 @@ class Worker:
             async with self.pool.pipeline(transaction=True) as pipe:
                 await pipe.watch(in_progress_key)
                 ongoing_exists = await pipe.exists(in_progress_key)
-                score = await pipe.zscore(self.queue_name, job_id)
-                if ongoing_exists or not score or score > timestamp_ms():
-                    # job already started elsewhere, or already finished and removed from queue
-                    # if score > ts_now,
-                    # it means probably the job was re-enqueued with a delay in another worker
+                score = await pipe.zscore(ready_queue_key(self.queue_name), job_id)
+                if ongoing_exists or not score:
+                    # job already started elsewhere, or already finished and removed from the
+                    # ready zset (e.g. re-deferred for retry by another worker)
                     self.job_counter = self.job_counter - 1
                     self.sem.release()
                     logger.debug('job %s already running elsewhere', job_id)
@@ -489,6 +540,7 @@ class Worker:
                 abort_job = False
 
         function_name, enqueue_time_ms = '<unknown>', 0
+        priority = DEFAULT_PRIORITY
         args: tuple[Any, ...] = ()
         kwargs: dict[Any, Any] = {}
 
@@ -505,6 +557,7 @@ class Worker:
                 start_ms=start_ms,
                 finished_ms=timestamp_ms(),
                 ref=f'{job_id}:{function_name}',
+                priority=priority,
                 serializer=self.job_serializer,
                 queue_name=self.queue_name,
                 job_id=job_id,
@@ -516,7 +569,7 @@ class Worker:
             return await job_failed(JobExecutionFailed('job expired'))
 
         try:
-            function_name, args, kwargs, enqueue_job_try, enqueue_time_ms = deserialize_job_raw(
+            function_name, args, kwargs, enqueue_job_try, enqueue_time_ms, priority = deserialize_job_raw(
                 v, deserializer=self.job_deserializer
             )
         except SerializationError as e:
@@ -564,6 +617,7 @@ class Worker:
                 ref,
                 self.queue_name,
                 job_id=job_id,
+                priority=priority,
                 serializer=self.job_serializer,
             )
             return await asyncio.shield(self.finish_failed_job(job_id, result_data))
@@ -589,8 +643,11 @@ class Worker:
         try:
             s = args_to_string(args, kwargs)
             extra = f' try={job_try}' if job_try > 1 else ''
-            if (start_ms - score) > 1200:
-                extra += f' delayed={(start_ms - score) / 1000:0.2f}s'
+            # `score` is the ready-zset score (PRIORITY_FACTOR*priority + run_at_ms);
+            # subtracting the priority bucket recovers the actual intended run time.
+            run_at_ms = score - PRIORITY_FACTOR * priority
+            if (start_ms - run_at_ms) > 1200:
+                extra += f' delayed={(start_ms - run_at_ms) / 1000:0.2f}s'
             logger.info('%6.2fs → %s(%s)%s', (start_ms - enqueue_time_ms) / 1000, ref, s, extra)
             self.job_tasks[job_id] = task = self.loop.create_task(function.coroutine(ctx, *args, **kwargs))
 
@@ -611,10 +668,11 @@ class Worker:
             finished_ms = timestamp_ms()
             t = (finished_ms - start_ms) / 1000
             if self.retry_jobs and isinstance(e, Retry):
+                # incr_score is interpreted as "defer-from-now in ms" by finish_job; the old
+                # zincrby-based math is no longer needed now that retry-with-defer rewrites
+                # the score absolutely against the deferred sub-zset.
                 incr_score = e.defer_score
                 logger.info('%6.2fs ↻ %s retrying job in %0.2fs', t, ref, (e.defer_score or 0) / 1000)
-                if e.defer_score:
-                    incr_score = e.defer_score + (timestamp_ms() - score)
                 self.jobs_retried += 1
             elif job_id in self.aborting_tasks and isinstance(e, asyncio.CancelledError):
                 logger.info('%6.2fs ⊘ %s aborted', t, ref)
@@ -658,6 +716,7 @@ class Worker:
                 ref,
                 self.queue_name,
                 job_id=job_id,
+                priority=priority,
                 serializer=self.job_serializer,
             )
 
@@ -703,9 +762,12 @@ class Worker:
                     tr.set(result_key_prefix + job_id, result_data, px=to_ms(expire))
                 delete_keys += [retry_key_prefix + job_id, job_key_prefix + job_id]
                 tr.zrem(abort_jobs_ss, job_id)
-                tr.zrem(self.queue_name, job_id)
+                ArqRedis.zrem_from_queue(tr, self.queue_name, job_id)
             elif incr_score:
-                tr.zincrby(self.queue_name, incr_score, job_id)
+                # retry-with-defer: move out of ready into deferred at run-at = now + incr_score ms
+                new_run_at_ms = timestamp_ms() + incr_score
+                tr.zrem(ready_queue_key(self.queue_name), job_id)
+                tr.zadd(deferred_queue_key(self.queue_name), {job_id: new_run_at_ms})
             if delete_keys:
                 tr.delete(*delete_keys)
             await tr.execute()
@@ -718,7 +780,7 @@ class Worker:
                 job_key_prefix + job_id,
             )
             tr.zrem(abort_jobs_ss, job_id)
-            tr.zrem(self.queue_name, job_id)
+            ArqRedis.zrem_from_queue(tr, self.queue_name, job_id)
             # result_data would only be None if serializing the result fails
             keep_result = self.keep_result_forever or self.keep_result_s > 0
             if result_data is not None and keep_result:  # pragma: no branch
@@ -776,10 +838,15 @@ class Worker:
             return
         self._last_health_check = now_ts
         pending_tasks = sum(not t.done() for t in self.tasks.values())
-        queued = await self.pool.zcard(self.queue_name)
+        async with self.pool.pipeline(transaction=False) as pipe:
+            pipe.zcard(ready_queue_key(self.queue_name))
+            pipe.zcard(deferred_queue_key(self.queue_name))
+            ready, deferred = await pipe.execute()
+        queued = int(ready) + int(deferred)
         info = (
             f'{datetime.now():%b-%d %H:%M:%S} j_complete={self.jobs_complete} j_failed={self.jobs_failed} '
-            f'j_retried={self.jobs_retried} j_ongoing={pending_tasks} queued={queued}'
+            f'j_retried={self.jobs_retried} j_ongoing={pending_tasks} queued={queued} '
+            f'ready={ready} deferred={deferred}'
         )
         await self.pool.psetex(  # type: ignore[no-untyped-call]
             self.health_check_key, int((self.health_check_interval + 1) * 1000), info.encode()

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -6,7 +6,13 @@ from dirty_equals import IsNow, IsStr
 
 from arq import Worker, func
 from arq.connections import ArqRedis, RedisSettings, create_pool
-from arq.constants import DEFAULT_PRIORITY, default_queue_name, in_progress_key_prefix, job_key_prefix, result_key_prefix
+from arq.constants import (
+    DEFAULT_PRIORITY,
+    default_queue_name,
+    in_progress_key_prefix,
+    job_key_prefix,
+    result_key_prefix,
+)
 from arq.jobs import (
     DeserializationError,
     Job,

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -6,7 +6,7 @@ from dirty_equals import IsNow, IsStr
 
 from arq import Worker, func
 from arq.connections import ArqRedis, RedisSettings, create_pool
-from arq.constants import default_queue_name, in_progress_key_prefix, job_key_prefix, result_key_prefix
+from arq.constants import DEFAULT_PRIORITY, default_queue_name, in_progress_key_prefix, job_key_prefix, result_key_prefix
 from arq.jobs import (
     DeserializationError,
     Job,
@@ -204,7 +204,24 @@ async def test_deserialize_info(arq_redis: ArqRedis):
 
 
 async def test_deserialize_job_raw():
-    assert deserialize_job_raw(pickle.dumps({'f': 1, 'a': 2, 'k': 3, 't': 4, 'et': 5})) == (1, 2, 3, 4, 5)
+    # legacy blob (no 'priority' key) -> default priority
+    assert deserialize_job_raw(pickle.dumps({'f': 1, 'a': 2, 'k': 3, 't': 4, 'et': 5})) == (
+        1,
+        2,
+        3,
+        4,
+        5,
+        DEFAULT_PRIORITY,
+    )
+    # new blob carrying explicit priority round-trips
+    assert deserialize_job_raw(pickle.dumps({'f': 1, 'a': 2, 'k': 3, 't': 4, 'et': 5, 'priority': 7})) == (
+        1,
+        2,
+        3,
+        4,
+        5,
+        7,
+    )
     with pytest.raises(DeserializationError, match='unable to deserialize job'):
         deserialize_job_raw(b'123')
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,7 +12,7 @@ import pytest
 from dirty_equals import IsInt, IsNow
 
 from arq.connections import ArqRedis, RedisSettings
-from arq.constants import default_queue_name
+from arq.constants import DEFAULT_PRIORITY, PRIORITY_FACTOR, default_queue_name, deferred_queue_key
 from arq.jobs import Job, JobDef, SerializationError
 from arq.utils import timestamp_ms
 from arq.worker import Retry, Worker, func
@@ -139,7 +139,8 @@ async def test_job_info(arq_redis: ArqRedis):
     assert info.function == 'foobar'
     assert info.args == (123,)
     assert info.kwargs == {'a': 456}
-    assert abs(t_before * 1000 - info.score) < 1000
+    # ready zset score is PRIORITY_FACTOR*priority + ts_ms; strip the priority bucket to recover ts.
+    assert abs(t_before * 1000 - (info.score - PRIORITY_FACTOR * DEFAULT_PRIORITY)) < 1000
 
 
 async def test_repeat_job(arq_redis: ArqRedis):
@@ -152,14 +153,14 @@ async def test_repeat_job(arq_redis: ArqRedis):
 async def test_defer_until(arq_redis: ArqRedis):
     j1 = await arq_redis.enqueue_job('foobar', _job_id='job_id', _defer_until=datetime(2032, 1, 1, tzinfo=timezone.utc))
     assert isinstance(j1, Job)
-    score = await arq_redis.zscore(default_queue_name, 'job_id')
+    score = await arq_redis.zscore(deferred_queue_key(default_queue_name), 'job_id')
     assert score == 1_956_528_000_000
 
 
 async def test_defer_by(arq_redis: ArqRedis):
     j1 = await arq_redis.enqueue_job('foobar', _job_id='job_id', _defer_by=20)
     assert isinstance(j1, Job)
-    score = await arq_redis.zscore(default_queue_name, 'job_id')
+    score = await arq_redis.zscore(deferred_queue_key(default_queue_name), 'job_id')
     ts = timestamp_ms()
     assert score > ts + 19000
     assert ts + 21000 > score
@@ -257,6 +258,7 @@ async def test_get_jobs(arq_redis: ArqRedis):
             'enqueue_time': IsNow(tz='UTC'),
             'score': IsInt(),
             'job_id': '1',
+            'priority': DEFAULT_PRIORITY,
         },
         {
             'function': 'second',
@@ -266,6 +268,7 @@ async def test_get_jobs(arq_redis: ArqRedis):
             'enqueue_time': IsNow(tz='UTC'),
             'score': IsInt(),
             'job_id': '2',
+            'priority': DEFAULT_PRIORITY,
         },
         {
             'function': 'third',
@@ -275,6 +278,7 @@ async def test_get_jobs(arq_redis: ArqRedis):
             'enqueue_time': IsNow(tz='UTC'),
             'score': IsInt(),
             'job_id': '3',
+            'priority': DEFAULT_PRIORITY,
         },
     ]
     assert jobs[0].score < jobs[1].score < jobs[2].score

--- a/tests/test_priority.py
+++ b/tests/test_priority.py
@@ -1,0 +1,199 @@
+"""End-to-end tests for priority-aware scheduling and the split ready/deferred sub-zsets."""
+
+import asyncio
+import pickle
+
+import pytest
+
+from arq.connections import ArqRedis
+from arq.constants import (
+    DEFAULT_PRIORITY,
+    MIN_PRIORITY,
+    PRIORITY_FACTOR,
+    compute_ready_score,
+    default_queue_name,
+    deferred_queue_key,
+    job_key_prefix,
+    ready_queue_key,
+)
+from arq.jobs import JobStatus, deserialize_job
+from arq.utils import timestamp_ms
+from arq.worker import Retry, Worker, func
+
+
+async def _enqueue(arq_redis: ArqRedis, fn: str, *args, **kwargs) -> str:
+    """Enqueue, then sleep 2ms so subsequent enqueues land at strictly larger timestamps."""
+    j = await arq_redis.enqueue_job(fn, *args, **kwargs)
+    await asyncio.sleep(0.002)
+    return j.job_id
+
+
+async def test_priority_ordering(arq_redis: ArqRedis, worker):
+    order: list[str] = []
+
+    async def record(ctx, tag):
+        order.append(tag)
+
+    await _enqueue(arq_redis, 'record', 'a', _priority=5)
+    await _enqueue(arq_redis, 'record', 'b', _priority=1)
+    await _enqueue(arq_redis, 'record', 'c', _priority=5)
+    await _enqueue(arq_redis, 'record', 'd', _priority=10)
+    await _enqueue(arq_redis, 'record', 'e', _priority=1)
+
+    w: Worker = worker(functions=[func(record, name='record')], max_jobs=1)
+    await w.main()
+
+    # priority-1 jobs first (FIFO between b and e), then the priority-5 jobs (FIFO between a and c),
+    # then priority-10.
+    assert order == ['b', 'e', 'a', 'c', 'd']
+
+
+async def test_priority_default_is_5(arq_redis: ArqRedis):
+    j = await arq_redis.enqueue_job('foobar')
+    info = await j.info()
+    assert info.priority == DEFAULT_PRIORITY
+    # ready zset score = PRIORITY_FACTOR * 5 + enqueue_time_ms
+    assert info.score >= PRIORITY_FACTOR * DEFAULT_PRIORITY
+    assert info.score < PRIORITY_FACTOR * (DEFAULT_PRIORITY + 1)
+
+
+@pytest.mark.parametrize('bad_priority', [0, 11, -1, 100])
+async def test_priority_validation(arq_redis: ArqRedis, bad_priority):
+    with pytest.raises(ValueError, match='_priority must be between'):
+        await arq_redis.enqueue_job('foobar', _priority=bad_priority)
+    assert await arq_redis.queue_size(default_queue_name) == 0
+
+
+async def test_priority_in_blob_round_trips(arq_redis: ArqRedis):
+    j = await arq_redis.enqueue_job('foobar', _priority=3)
+    blob = await arq_redis.get(job_key_prefix + j.job_id)
+    assert blob is not None
+    restored = deserialize_job(blob)
+    assert restored.priority == 3
+
+
+async def test_deferred_lives_in_deferred_zset(arq_redis: ArqRedis):
+    before = timestamp_ms()
+    j = await arq_redis.enqueue_job('foobar', _defer_by=60, _priority=2)
+    after = timestamp_ms()
+
+    assert await arq_redis.zcard(deferred_queue_key(default_queue_name)) == 1
+    assert await arq_redis.zcard(ready_queue_key(default_queue_name)) == 0
+
+    assert await j.status() == JobStatus.deferred
+
+    # deferred score is the raw run-at timestamp (no priority bucket).
+    score = await arq_redis.zscore(deferred_queue_key(default_queue_name), j.job_id)
+    assert before + 60_000 <= score <= after + 60_000
+
+
+async def test_promote_deferred_to_ready_uses_priority(arq_redis: ArqRedis, worker):
+    async def noop(ctx):
+        pass
+
+    # Tiny defer so promotion happens after one short sleep.
+    await arq_redis.enqueue_job('noop', _job_id='lo', _defer_by=0.005, _priority=5)
+    await arq_redis.enqueue_job('noop', _job_id='hi', _defer_by=0.005, _priority=1)
+
+    assert await arq_redis.zcard(deferred_queue_key(default_queue_name)) == 2
+    assert await arq_redis.zcard(ready_queue_key(default_queue_name)) == 0
+
+    await asyncio.sleep(0.05)
+
+    w: Worker = worker(functions=[func(noop, name='noop')])
+    await w._promote_deferred_jobs()
+
+    assert await arq_redis.zcard(deferred_queue_key(default_queue_name)) == 0
+    assert await arq_redis.zcard(ready_queue_key(default_queue_name)) == 2
+
+    entries = await arq_redis.zrange(ready_queue_key(default_queue_name), 0, -1, withscores=True)
+    by_id = {jid.decode(): int(s) for jid, s in entries}
+    # priority=1 has lower score than priority=5 -> picked first.
+    assert by_id['hi'] < by_id['lo']
+    # bucket sanity: scores live in their priority bucket.
+    assert PRIORITY_FACTOR * 1 <= by_id['hi'] < PRIORITY_FACTOR * 2
+    assert PRIORITY_FACTOR * 5 <= by_id['lo'] < PRIORITY_FACTOR * 6
+
+
+async def test_retry_with_defer_moves_to_deferred_zset(arq_redis: ArqRedis, worker):
+    attempts = {'n': 0}
+
+    async def sometimes_retries(ctx):
+        attempts['n'] += 1
+        if attempts['n'] == 1:
+            raise Retry(defer=0.05)
+        return 'done'
+
+    j = await arq_redis.enqueue_job('sometimes_retries', _job_id='retry-job')
+    w: Worker = worker(functions=[func(sometimes_retries, name='sometimes_retries')])
+
+    # First poll: run -> Retry(defer) -> moved into deferred zset.
+    await w._poll_iteration()
+    await asyncio.gather(*w.tasks.values())
+
+    assert attempts['n'] == 1
+    assert await arq_redis.zcard(ready_queue_key(default_queue_name)) == 0
+    assert await arq_redis.zcard(deferred_queue_key(default_queue_name)) == 1
+
+    # After the defer window, second poll promotes + runs the job to completion.
+    await asyncio.sleep(0.1)
+    await w._poll_iteration()
+    await asyncio.gather(*w.tasks.values())
+
+    assert attempts['n'] == 2
+    assert await arq_redis.queue_size(default_queue_name) == 0
+    assert await j.status() == JobStatus.complete
+
+
+async def test_abort_deferred_job_moves_to_ready(arq_redis: ArqRedis):
+    j = await arq_redis.enqueue_job('noop', _defer_by=600, _priority=8)
+    assert await arq_redis.zcard(deferred_queue_key(default_queue_name)) == 1
+
+    # Job.abort does its zrem/zadd up front, then blocks waiting for the worker to mark the
+    # job complete. We don't have a worker running, so kick off abort as a task, give it a
+    # moment to perform the zset moves, then cancel.
+    abort_task = asyncio.create_task(j.abort(poll_delay=0.01))
+    try:
+        await asyncio.sleep(0.05)
+
+        assert await arq_redis.zcard(deferred_queue_key(default_queue_name)) == 0
+        assert await arq_redis.zcard(ready_queue_key(default_queue_name)) == 1
+
+        score = int(await arq_redis.zscore(ready_queue_key(default_queue_name), j.job_id))
+        # promoted at top priority regardless of original priority
+        assert PRIORITY_FACTOR * MIN_PRIORITY <= score < PRIORITY_FACTOR * (MIN_PRIORITY + 1)
+    finally:
+        abort_task.cancel()
+        # Job.abort swallows CancelledError and returns True; either outcome is fine here.
+        try:
+            await abort_task
+        except asyncio.CancelledError:
+            pass
+
+
+async def test_status_deferred_vs_queued(arq_redis: ArqRedis):
+    ready_job = await arq_redis.enqueue_job('foobar')
+    deferred_job = await arq_redis.enqueue_job('foobar', _defer_by=60)
+
+    assert await ready_job.status() == JobStatus.queued
+    assert await deferred_job.status() == JobStatus.deferred
+
+
+async def test_queue_size_helper_sums_subzsets(arq_redis: ArqRedis):
+    for _ in range(2):
+        await arq_redis.enqueue_job('foobar')
+    for _ in range(3):
+        await arq_redis.enqueue_job('foobar', _defer_by=60)
+
+    assert await arq_redis.zcard(ready_queue_key(default_queue_name)) == 2
+    assert await arq_redis.zcard(deferred_queue_key(default_queue_name)) == 3
+    assert await arq_redis.queue_size(default_queue_name) == 5
+
+
+async def test_legacy_blob_deserializes_with_default_priority():
+    # blobs written by old arq versions don't have a 'priority' key
+    legacy = pickle.dumps({'f': 'foo', 'a': (), 'k': {}, 't': None, 'et': timestamp_ms()})
+    jd = deserialize_job(legacy)
+    assert jd.priority == DEFAULT_PRIORITY
+    # sanity: round-trip score helper agrees with the formula
+    assert compute_ready_score(jd.priority, 100) == PRIORITY_FACTOR * DEFAULT_PRIORITY + 100

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -12,7 +12,14 @@ import pytest
 import redis.exceptions
 
 from arq.connections import ArqRedis, RedisSettings
-from arq.constants import abort_jobs_ss, default_queue_name, expires_extra_ms, health_check_key_suffix, job_key_prefix
+from arq.constants import (
+    abort_jobs_ss,
+    default_queue_name,
+    expires_extra_ms,
+    health_check_key_suffix,
+    job_key_prefix,
+    ready_queue_key,
+)
 from arq.jobs import Job, JobStatus
 from arq.worker import (
     FailedJobs,
@@ -612,7 +619,10 @@ async def test_error_success(arq_redis: ArqRedis, worker):
 async def test_many_jobs_expire(arq_redis: ArqRedis, worker, caplog):
     caplog.set_level(logging.INFO)
     await arq_redis.enqueue_job('foobar')
-    await asyncio.gather(*[arq_redis.zadd(default_queue_name, {f'testing-{i}': 1}) for i in range(100)])
+    # seed 100 dangling entries in the ready zset (no matching job blob) -> they hit the "expired" path.
+    await asyncio.gather(
+        *[arq_redis.zadd(ready_queue_key(default_queue_name), {f'testing-{i}': 1}) for i in range(100)]
+    )
     worker: Worker = worker(functions=[foobar])
     assert worker.jobs_complete == 0
     assert worker.jobs_failed == 0
@@ -644,7 +654,7 @@ async def test_queue_read_limit_equals_max_jobs(arq_redis: ArqRedis, worker):
     for _ in range(4):
         await arq_redis.enqueue_job('foobar')
 
-    assert await arq_redis.zcard(default_queue_name) == 4
+    assert await arq_redis.queue_size(default_queue_name) == 4
     worker: Worker = worker(functions=[foobar], queue_read_limit=2)
     assert worker.queue_read_limit == 2
     assert worker.jobs_complete == 0
@@ -653,14 +663,14 @@ async def test_queue_read_limit_equals_max_jobs(arq_redis: ArqRedis, worker):
 
     await worker._poll_iteration()
     await asyncio.sleep(0.1)
-    assert await arq_redis.zcard(default_queue_name) == 2
+    assert await arq_redis.queue_size(default_queue_name) == 2
     assert worker.jobs_complete == 2
     assert worker.jobs_failed == 0
     assert worker.jobs_retried == 0
 
     await worker._poll_iteration()
     await asyncio.sleep(0.1)
-    assert await arq_redis.zcard(default_queue_name) == 0
+    assert await arq_redis.queue_size(default_queue_name) == 0
     assert worker.jobs_complete == 4
     assert worker.jobs_failed == 0
     assert worker.jobs_retried == 0
@@ -677,7 +687,7 @@ async def test_custom_queue_read_limit(arq_redis: ArqRedis, worker):
     for _ in range(4):
         await arq_redis.enqueue_job('foobar')
 
-    assert await arq_redis.zcard(default_queue_name) == 4
+    assert await arq_redis.queue_size(default_queue_name) == 4
     worker: Worker = worker(functions=[foobar], max_jobs=4, queue_read_limit=2)
     assert worker.jobs_complete == 0
     assert worker.jobs_failed == 0
@@ -685,14 +695,14 @@ async def test_custom_queue_read_limit(arq_redis: ArqRedis, worker):
 
     await worker._poll_iteration()
     await asyncio.sleep(0.1)
-    assert await arq_redis.zcard(default_queue_name) == 2
+    assert await arq_redis.queue_size(default_queue_name) == 2
     assert worker.jobs_complete == 2
     assert worker.jobs_failed == 0
     assert worker.jobs_retried == 0
 
     await worker._poll_iteration()
     await asyncio.sleep(0.1)
-    assert await arq_redis.zcard(default_queue_name) == 0
+    assert await arq_redis.queue_size(default_queue_name) == 0
     assert worker.jobs_complete == 4
     assert worker.jobs_failed == 0
     assert worker.jobs_retried == 0

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -524,7 +524,7 @@ async def test_log_health_check(arq_redis: ArqRedis, worker, caplog):
 async def test_remain_keys(test_redis_settings: RedisSettings, arq_redis: ArqRedis, worker, create_pool):
     redis2 = await create_pool(test_redis_settings)
     await arq_redis.enqueue_job('foobar', _job_id='testing')
-    assert sorted(await redis2.keys('*')) == [b'arq:job:testing', b'arq:queue']
+    assert sorted(await redis2.keys('*')) == [b'arq:job:testing', b'arq:queue:ready']
     worker: Worker = worker(functions=[foobar])
     await worker.main()
     assert sorted(await redis2.keys('*')) == [b'arq:queue:health-check', b'arq:result:testing']
@@ -534,7 +534,7 @@ async def test_remain_keys(test_redis_settings: RedisSettings, arq_redis: ArqRed
 
 async def test_remain_keys_no_results(arq_redis: ArqRedis, worker):
     await arq_redis.enqueue_job('foobar', _job_id='testing')
-    assert sorted(await arq_redis.keys('*')) == [b'arq:job:testing', b'arq:queue']
+    assert sorted(await arq_redis.keys('*')) == [b'arq:job:testing', b'arq:queue:ready']
     worker: Worker = worker(functions=[func(foobar, keep_result=0)])
     await worker.main()
     assert sorted(await arq_redis.keys('*')) == [b'arq:queue:health-check']
@@ -542,7 +542,7 @@ async def test_remain_keys_no_results(arq_redis: ArqRedis, worker):
 
 async def test_remain_keys_keep_results_forever_in_function(arq_redis: ArqRedis, worker):
     await arq_redis.enqueue_job('foobar', _job_id='testing')
-    assert sorted(await arq_redis.keys('*')) == [b'arq:job:testing', b'arq:queue']
+    assert sorted(await arq_redis.keys('*')) == [b'arq:job:testing', b'arq:queue:ready']
     worker: Worker = worker(functions=[func(foobar, keep_result_forever=True)])
     await worker.main()
     assert sorted(await arq_redis.keys('*')) == [b'arq:queue:health-check', b'arq:result:testing']
@@ -552,7 +552,7 @@ async def test_remain_keys_keep_results_forever_in_function(arq_redis: ArqRedis,
 
 async def test_remain_keys_keep_results_forever(arq_redis: ArqRedis, worker):
     await arq_redis.enqueue_job('foobar', _job_id='testing')
-    assert sorted(await arq_redis.keys('*')) == [b'arq:job:testing', b'arq:queue']
+    assert sorted(await arq_redis.keys('*')) == [b'arq:job:testing', b'arq:queue:ready']
     worker: Worker = worker(functions=[func(foobar)], keep_result_forever=True)
     await worker.main()
     assert sorted(await arq_redis.keys('*')) == [b'arq:queue:health-check', b'arq:result:testing']


### PR DESCRIPTION
## Problem

arq schedules jobs strictly FIFO — every job sits in a single per-queue Redis sorted set keyed
by enqueue time, and the worker pops the lowest score first. There's no way to express
"this job should jump ahead of the backlog" short of standing up a separate queue with its
own worker, which is operationally heavy and breaks fair sharing of `max_jobs`.

## Solution

Introduce per-job priority `1..10` (lower number = higher priority, default `5`) and split
each queue's single sorted set into two sub-zsets that the rest of the code routes through:

- `{queue}:ready` — jobs eligible to run now. Score = `PRIORITY_FACTOR * priority + enqueue_time_ms`
  (`PRIORITY_FACTOR = 10**15`). Lower score wins, so priority drives the bucket and enqueue
  time is the FIFO tiebreak within a bucket.
- `{queue}:deferred` — jobs waiting on `_defer_until` / `_defer_by`. Score = run-at ms (no
  priority bucket — the priority is stashed in the pickled job blob under a new `'priority'`
  key and applied at promotion time).

`Worker._poll_iteration` now starts with a `_promote_deferred_jobs()` step that moves every
deferred entry whose run-at time has passed into the ready zset using the recovered priority.
Promotion is idempotent (`ZADD` + `ZREM`) so concurrent workers can race safely. After
promotion the worker reads the head of the ready zset as before — no time filter needed
since deferred state is now structural.

`enqueue_job` gains `_priority: int = 5` and validates the range. Retry-with-defer
(`Retry(defer=…)`) writes back into `{queue}:deferred` with an absolute `now + defer_ms`
score (replacing the old `ZINCRBY` math). Aborting a deferred job hoists it into ready at
top priority so the abort flag is observed on the next poll. `Job.status` / `info` /
`result` / `abort` and `queued_jobs` / `record_health` / burst-exit all consult both
sub-zsets via three small helpers on `ArqRedis` (`queue_size`, `job_queue_score`,
`zrem_from_queue`) plus pure utilities in `arq.constants` (`ready_queue_key`,
`deferred_queue_key`, `compute_ready_score`).

## Backwards compatibility

- `JobDef.priority` and the new `JobResult` field defaults are tolerant — hand-written
  constructor literals that predate this PR keep compiling. The wire format adds a
  `'priority'` key in pickled blobs; readers fall back to the default when it's missing,
  so a new client can talk to an old worker and vice versa.
- `deserialize_job_raw` now returns a 6-tuple (priority appended); this is a low-level
  internal helper but is exported, so external callers unpacking into 5 names will need
  to update.
- The Redis key layout changes (`arq:queue` -> `arq:queue:ready` + `arq:queue:deferred`).
  Existing in-flight queues should be drained before deploying this version. No automatic
  migration is performed.

## Tests

New `tests/test_priority.py` covers:

- Execution ordering across mixed priorities with FIFO tiebreak (`max_jobs=1`).
- Default priority of 5, validation of out-of-range values, blob round-trip.
- Deferred jobs land in `{queue}:deferred`; promotion moves them into `{queue}:ready` with
  the right priority-bucketed score.
- `Retry(defer=…)` moves the job out of ready and into deferred, then promotes & runs to
  completion after the wait.
- Aborting a deferred job moves it into ready at `MIN_PRIORITY`.
- Status reflects ready vs. deferred structurally; `queue_size` sums both sub-zsets.
- Legacy blob (no `'priority'` key) deserializes with the default.

Updated existing tests where they poked at the legacy single-zset directly
(`test_main.py::test_defer_until` / `test_defer_by` / `test_job_info` / `test_get_jobs`,
`test_jobs.py::test_deserialize_job_raw`, `test_worker.py::test_many_jobs_expire` /
`test_queue_read_limit_equals_max_jobs` / `test_custom_queue_read_limit`) to point at the
new sub-zsets / `queue_size` helper.

## Notes for reviewers

- `PRIORITY_FACTOR = 10**15` keeps the priority bucket strictly above any realistic
  `timestamp_ms` while staying inside the IEEE-754 double precision range Redis uses for
  scores; smallest representable gap at `~1e16` is `2.0`, so ms-level ordering still
  resolves correctly. Could be dropped to `1e13` if you'd rather have more headroom.
- Cron jobs are unchanged — they enqueue through `enqueue_job` and inherit the default
  priority. Exposing `_priority` on `CronJob` is left as a follow-up.