### PR TITLE
Reject decode_responses=True in ArqRedis with a clear error

### DIFF
--- a/arq/connections.py
+++ b/arq/connections.py
@@ -96,7 +96,8 @@ class ArqRedis(BaseRedis):
     :param default_queue_name: the default queue name to use, defaults to ``arq.queue``.
     :param expires_extra_ms: the default length of time from when a job is expected to start
      after which the job expires, defaults to 1 day in ms.
-    :param kwargs: keyword arguments directly passed to ``redis.asyncio.Redis``.
+    :param kwargs: keyword arguments directly passed to ``redis.asyncio.Redis``. Note that
+     ``decode_responses=True`` is not supported since arq stores job data as raw bytes.
     """
 
     def __init__(
@@ -115,6 +116,13 @@ class ArqRedis(BaseRedis):
             kwargs['connection_pool'] = pool_or_conn
         self.expires_extra_ms = expires_extra_ms
         super().__init__(**kwargs)
+        if self.connection_pool.connection_kwargs.get('decode_responses'):
+            raise RuntimeError(
+                'arq does not support decode_responses=True: job data is stored and '
+                'deserialized as raw bytes (via pickle/msgpack), so decoded string '
+                'responses will corrupt job execution rather than fail clearly. Remove '
+                "'decode_responses' from your redis connection settings."
+            )
 
     async def enqueue_job(
         self,

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -1,0 +1,18 @@
+import pytest
+
+from arq.connections import ArqRedis
+
+
+def test_decode_responses_rejected():
+    with pytest.raises(RuntimeError, match='decode_responses'):
+        ArqRedis(host='localhost', port=6379, decode_responses=True)
+
+
+def test_decode_responses_false_is_fine():
+    redis_ = ArqRedis(host='localhost', port=6379, decode_responses=False)
+    assert redis_.connection_pool.connection_kwargs.get('decode_responses') is False
+
+
+def test_decode_responses_unset_is_fine():
+    redis_ = ArqRedis(host='localhost', port=6379)
+    assert not redis_.connection_pool.connection_kwargs.get('decode_responses')


### PR DESCRIPTION
Closes #505.

## Problem

arq stores and deserializes job data as raw `bytes` (via pickle/msgpack). `create_pool()` never exposed `decode_responses`, but nothing stopped a user from constructing `ArqRedis` directly with `decode_responses=True`, or handing it a pre-built connection pool with that set. When that happens, internal code that assumes bytes (e.g. `.decode()` calls on job/result keys in `_get_job_result`/`_get_job_def`, and the job (de)serializers) breaks with confusing downstream errors instead of a clear message pointing at the actual cause.

## Fix

`ArqRedis.__init__` now checks the resolved `connection_pool.connection_kwargs` right after `super().__init__()` and raises a `RuntimeError` immediately if `decode_responses` is truthy. Checking the resolved connection pool (rather than just the raw kwarg) means it catches the setting regardless of how it reaches `ArqRedis` — a direct kwarg, or a pre-built pool passed via `pool_or_conn` (which is also the path `create_pool()`'s `Sentinel` branch and manual pool construction go through).

Also updated the `ArqRedis` docstring to note the restriction.

## Testing

Added `tests/test_connections.py` covering:
- `decode_responses=True` is rejected with a clear error
- `decode_responses=False` (explicit) still works
- `decode_responses` unset (existing default behavior) still works

Also manually verified the `pool_or_conn`-based construction path (used by `create_pool`) is caught the same way. No existing behavior changes for anyone not passing `decode_responses`.