### PR TITLE
Stop pytest-timeout from killing Redis Docker image pull

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,9 @@ filterwarnings = [
 ]
 asyncio_mode = 'auto'
 timeout = 10
+# Exclude fixture setup/teardown so session-scoped redis_container can pull the
+# Docker image on a cold cache without being killed by the 10s per-test timeout.
+timeout_func_only = true
 
 [tool.coverage.run]
 source = ['arq']


### PR DESCRIPTION
CI flakes when the session-scoped redis_container fixture pulls a Redis image under the global 10s pytest-timeout. A cold cache or slow network makes docker.images.pull exceed 10s; pytest-timeout then kills whichever test first triggers the fixture.

pyproject.toml already has timeout = 10. This change sets pytest-timeout timeout_func_only = true so the 10s limit applies only to test function bodies, not fixture setup/teardown. Container image pull and start are therefore outside that budget. Individual tests stay under 10s.

No tests are removed or weakened.

Fixes #529